### PR TITLE
Fix Xavier2 compilation errors

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,31 @@ pub struct Cli {
     pub command: Command,
 }
 
+#[derive(Subcommand)]
+pub enum Command {
+    /// Start HTTP API server
+    Http {
+        #[arg(short, long, default_value_t = 8006)]
+        port: u16,
+    },
+    /// Start MCP-stdio server
+    Mcp,
+    /// Search memories from a running server
+    Search {
+        query: String,
+        #[arg(short, long, default_value_t = 10)]
+        limit: usize,
+    },
+    /// Add a memory via a running server
+    Add {
+        content: String,
+        #[arg(short, long)]
+        title: Option<String>,
+    },
+    /// Show stats from a running server
+    Stats,
+}
+
 impl Cli {
     pub async fn run(&self) -> Result<()> {
         match &self.command {
@@ -30,7 +55,7 @@ impl Cli {
                 search_memories(query, *limit).await
             }
             Command::Add { content, title } => {
-                let title_display = title.unwrap_or("Untitled");
+                let title_display = title.as_deref().unwrap_or("Untitled");
                 println!("Adding memory: {}", title_display);
                 add_memory(content, title.as_deref()).await
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use clap::Parser;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-use xavier2::cli::Cli;
+use crate::cli::Cli;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -2,6 +2,7 @@
 
 use axum::{
     extract::{Query, State},
+    http::StatusCode,
     response::IntoResponse,
     Extension, Json,
 };
@@ -15,10 +16,9 @@ use tracing::{info, warn, error};
 
 use crate::{
     agents::provider::ModelProviderClient,
-    agents::runtime::AgentRunTrace,
-    agents::runtime::System3Mode,
+    agents::runtime::{AgentRunTrace, System3Mode},
     consolidation::ConsolidationTask,
-    consistency::regularization::{CoherenceReport, RetentionRegularizer},
+    consistency::{CoherenceReport, RetentionRegularizer},
     embedding,
     memory::belief_graph::{BeliefNode, BeliefRelation},
     memory::entity_graph::EntityRecord,
@@ -105,14 +105,12 @@ impl Default for ShutdownState {
 /// Returns a handle to the task; dropping the handle does NOT cancel the task.
 pub async fn start_signal_handler(state: ShutdownState) {
     tokio::spawn(async move {
-        use tokio::signal::windows::{ctrl_c, ctrl_break, ctrl_close, ctrl_logoff, ctrl_shutdown};
-        use tokio::signal::unix::{signal, SignalKind};
-
         let mut shutdown_reason: Option<&'static str> = None;
 
         // Unix signals (SIGTERM / SIGINT)
         #[cfg(unix)]
         {
+            use tokio::signal::unix::{signal, SignalKind};
             let mut sigterm = match signal(SignalKind::terminate()) {
                 Ok(s) => s,
                 Err(e) => {
@@ -137,6 +135,7 @@ pub async fn start_signal_handler(state: ShutdownState) {
         // Windows console events
         #[cfg(windows)]
         {
+            use tokio::signal::windows::ctrl_c;
             let mut ctrl_events = async {
                 let mut rx = ctrl_c().expect("failed to subscribe to Ctrl+C");
                 rx.recv().await
@@ -144,7 +143,8 @@ pub async fn start_signal_handler(state: ShutdownState) {
 
             let reason = ctrl_events.await;
             match reason {
-                Ok(()) | Err(_) => shutdown_reason = Some("Ctrl+C / console close"),
+                Some(Ok(())) | Some(Err(_)) => shutdown_reason = Some("Ctrl+C / console close"),
+                None => {}
             }
         }
 
@@ -186,7 +186,7 @@ pub fn install_panic_hook() {
             concat!(
                 "══════════════════════════════════════════════════\n",
                 "  🔥 PANIC in Xavier2 ({})\n",
-                "  Thread: {}{}\n",
+                "  Thread: {}\n",
                 "  Location: {}\n",
                 "  Message: {}\n",
                 "══════════════════════════════════════════════════\n"
@@ -1174,10 +1174,10 @@ pub async fn memory_reflect(Extension(workspace): Extension<WorkspaceContext>) -
     info!("🪞 Memory reflection request");
     let task = ConsolidationTask::default();
     match task.reflect(&workspace).await {
-        Ok(result) => Json(result),
+        Ok(result) => Json(result).into_response(),
         Err(e) => {
             error!("Memory reflect error: {:?}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
     }
 }


### PR DESCRIPTION
I have fixed the 5 reported compilation errors plus several others I discovered during verification. 

Key changes:
1. **src/server/http.rs**: Updated the shutdown handler's match pattern, fixed multiple import errors (including missing re-exports and `StatusCode`), resolved a type mismatch in the `memory_reflect` handler, and fixed a format string bug in the panic hook.
2. **src/main.rs**: Updated the `Cli` import to use `crate::cli::Cli` instead of `xavier2::cli::Cli` which was causing an unresolved import error.
3. **src/cli.rs**: Added the missing `Command` enum which was causing multiple "not found in this scope" errors. Also fixed a type mismatch where a `String` was expected but a `&str` was provided.

The `xavier2` crate (both library and binary) now passes `cargo check` successfully.

Fixes #16

---
*PR created automatically by Jules for task [18236683577076420859](https://jules.google.com/task/18236683577076420859) started by @iberi22*