### PR TITLE
Add session_load tool to restore context

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1069,6 +1069,20 @@ async fn start_mcp_stdio() -> Result<()> {
                             }
                         },
                         {
+                            "name": "session_load",
+                            "description": "Restore context on session start",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "session_id": {
+                                        "type": "string",
+                                        "description": "Session ID to load context for"
+                                    }
+                                },
+                                "required": ["session_id"]
+                            }
+                        },
+                        {
                             "name": "stats",
                             "description": "Get Xavier2 memory statistics (total count, cache metrics)",
                             "inputSchema": {
@@ -1142,6 +1156,25 @@ async fn start_mcp_stdio() -> Result<()> {
                             Err(e) => format!("{{\"error\": \"{}\"}}", e),
                         }
                     }
+                    "session_load" => {
+                        let session_id = args.get("session_id").and_then(|v| v.as_str()).unwrap_or("");
+                        match memory.get_session_context(session_id).await {
+                            Ok(Some(doc)) => {
+                                serde_json::json!({
+                                    "status": "ok",
+                                    "content": doc.content,
+                                    "metadata": doc.metadata,
+                                }).to_string()
+                            }
+                            Ok(None) => {
+                                serde_json::json!({
+                                    "status": "not_found",
+                                    "message": format!("No context found for session {}", session_id),
+                                }).to_string()
+                            }
+                            Err(e) => format!("{{\"error\": \"{}\"}}", e),
+                        }
+                    }
                     "stats" => {
                         let count = memory.count().await.unwrap_or(0);
                         let usage = memory.usage().await;
@@ -1158,7 +1191,7 @@ async fn start_mcp_stdio() -> Result<()> {
                         .to_string()
                     }
                     _ => format!(
-                        "Unknown tool: {}. Available tools: search, add, stats",
+                        "Unknown tool: {}. Available tools: search, add, session_load, stats",
                         tool_name
                     ),
                 };

--- a/src/memory/qmd_memory.rs
+++ b/src/memory/qmd_memory.rs
@@ -668,6 +668,12 @@ impl QmdMemory {
             .cloned())
     }
 
+    /// Retrieve session context document specifically
+    pub async fn get_session_context(&self, session_id: &str) -> Result<Option<MemoryDocument>> {
+        let path = format!("sessions/{}/context", session_id);
+        self.get(&path).await
+    }
+
     pub async fn add(&self, doc: MemoryDocument) -> Result<()> {
         self.docs.write().await.push(doc.clone());
         self.invalidate_cache().await;
@@ -3009,6 +3015,26 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("D1:3")
         );
+    }
+
+    #[tokio::test]
+    async fn get_session_context_retrieves_correct_document() {
+        let memory = QmdMemory::new(Arc::new(RwLock::new(Vec::new())));
+        let session_id = "test-session-123";
+        let context_content = "This is the saved context.";
+        let path = format!("sessions/{}/context", session_id);
+
+        memory
+            .add_document(path.clone(), context_content.to_string(), serde_json::json!({}))
+            .await
+            .unwrap();
+
+        let context = memory.get_session_context(session_id).await.unwrap();
+        assert!(context.is_some());
+        assert_eq!(context.unwrap().content, context_content);
+
+        let non_existent = memory.get_session_context("other-session").await.unwrap();
+        assert!(non_existent.is_none());
     }
 
     #[tokio::test]

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -96,8 +96,6 @@ impl Default for ShutdownState {
 /// Returns a handle to the task; dropping the handle does NOT cancel the task.
 pub async fn start_signal_handler(state: ShutdownState) {
     tokio::spawn(async move {
-        use tokio::signal::windows::ctrl_c;
-
         let mut shutdown_reason: Option<&'static str> = None;
 
         // Unix signals (SIGTERM / SIGINT)
@@ -128,6 +126,7 @@ pub async fn start_signal_handler(state: ShutdownState) {
         // Windows console events
         #[cfg(windows)]
         {
+            use tokio::signal::windows::ctrl_c;
             let ctrl_events = async {
                 let mut rx = ctrl_c().expect("failed to subscribe to Ctrl+C");
                 rx.recv().await


### PR DESCRIPTION
This PR adds the `session_load` tool to the Xavier2 CLI/MCP server, completing the context management lifecycle. It allows restoring saved session context from the vector store on session start.

Key changes:
- `src/memory/qmd_memory.rs`: Added `get_session_context` method and a unit test.
- `src/cli.rs`: Added `session_load` to MCP tool definitions and implemented its logic.
- `src/server/http.rs`: Fixed a compilation error where a Windows-only import was not properly gated.

Fixes #49

---
*PR created automatically by Jules for task [8879868682950797465](https://jules.google.com/task/8879868682950797465) started by @iberi22*