### PR TITLE
Add session_save tool to save context before overflow

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,6 +145,7 @@ async fn start_http_server(port: u16) -> Result<()> {
         .route("/ready", get(readiness_handler))
         .route("/security/scan", post(security_scan_handler))
         .route("/memory/query", post(memory_query_handler))
+        .route("/session/save", post(session_save_handler))
         .with_state(state);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -443,6 +444,64 @@ struct MemoryQueryPayload {
     query: String,
     limit: Option<usize>,
     filters: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionSavePayload {
+    session_id: String,
+    content: String,
+}
+
+async fn session_save_handler(
+    State(state): State<CliState>,
+    axum::Json(payload): axum::Json<SessionSavePayload>,
+) -> impl axum::response::IntoResponse {
+    // Validate session_id to prevent path traversal
+    if payload.session_id.contains('/') || payload.session_id.contains('\\') || payload.session_id.contains("..") {
+        return axum::Json(serde_json::json!({
+            "status": "error",
+            "message": "Invalid session_id: path traversal patterns detected",
+        }));
+    }
+
+    // Security scan on content
+    let sec_result = state.security.process_input(&payload.content);
+    if !sec_result.allowed {
+        return axum::Json(serde_json::json!({
+            "status": "blocked",
+            "reason": "security_policy_violation",
+            "detection": {
+                "is_injection": sec_result.detection.is_injection,
+                "confidence": sec_result.detection.confidence,
+                "attack_type": sec_result.detection.attack_type.as_str(),
+            }
+        }));
+    }
+
+    let effective_content = sec_result.effective_input().to_string();
+
+    match state
+        .memory
+        .save_session_context(&payload.session_id, effective_content)
+        .await
+    {
+        Ok(path) => {
+            info!("Session context saved: {}", path);
+            axum::Json(serde_json::json!({
+                "status": "ok",
+                "message": "Session context saved",
+                "path": path,
+                "session_id": payload.session_id,
+            }))
+        }
+        Err(e) => {
+            info!("Session save error: {}", e);
+            axum::Json(serde_json::json!({
+                "status": "error",
+                "message": e.to_string(),
+            }))
+        }
+    }
 }
 
 async fn memory_query_handler(
@@ -1075,6 +1134,24 @@ async fn start_mcp_stdio() -> Result<()> {
                                 "type": "object",
                                 "properties": {}
                             }
+                        },
+                        {
+                            "name": "session_save",
+                            "description": "Save current session context before overflow",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "session_id": {
+                                        "type": "string",
+                                        "description": "Session identifier"
+                                    },
+                                    "content": {
+                                        "type": "string",
+                                        "description": "Full session context to save"
+                                    }
+                                },
+                                "required": ["session_id", "content"]
+                            }
                         }
                     ]
                 }
@@ -1157,8 +1234,46 @@ async fn start_mcp_stdio() -> Result<()> {
                         })
                         .to_string()
                     }
+                    "session_save" => {
+                        let session_id = args.get("session_id").and_then(|v| v.as_str()).unwrap_or("");
+                        let content = args.get("content").and_then(|v| v.as_str()).unwrap_or("");
+
+                        // Validate session_id to prevent path traversal
+                        if session_id.contains('/') || session_id.contains('\\') || session_id.contains("..") {
+                            serde_json::json!({
+                                "status": "error",
+                                "message": "Invalid session_id: path traversal patterns detected",
+                            }).to_string()
+                        } else {
+                            // Security scan on content
+                            let security = SecurityService::new();
+                            let sec_result = security.process_input(content);
+
+                            if !sec_result.allowed {
+                                serde_json::json!({
+                                    "status": "blocked",
+                                    "reason": "security_policy_violation",
+                                    "detection": {
+                                        "is_injection": sec_result.detection.is_injection,
+                                        "confidence": sec_result.detection.confidence,
+                                        "attack_type": sec_result.detection.attack_type.as_str(),
+                                    }
+                                }).to_string()
+                            } else {
+                                let effective_content = sec_result.effective_input().to_string();
+                                match memory.save_session_context(session_id, effective_content).await {
+                                    Ok(path) => serde_json::json!({
+                                        "status": "ok",
+                                        "path": path,
+                                        "session_id": session_id,
+                                    }).to_string(),
+                                    Err(e) => format!("{{\"error\": \"{}\"}}", e),
+                                }
+                            }
+                        }
+                    }
                     _ => format!(
-                        "Unknown tool: {}. Available tools: search, add, stats",
+                        "Unknown tool: {}. Available tools: search, add, stats, session_save",
                         tool_name
                     ),
                 };

--- a/src/memory/qmd_memory.rs
+++ b/src/memory/qmd_memory.rs
@@ -777,6 +777,20 @@ impl QmdMemory {
         Ok(id)
     }
 
+    /// Save full session context to persistent memory.
+    /// This is used before context window overflow to ensure continuity.
+    pub async fn save_session_context(&self, session_id: &str, content: String) -> Result<String> {
+        let path = format!("sessions/{}/context", session_id);
+        let metadata = serde_json::json!({
+            "session_id": session_id,
+            "type": "session_context",
+            "saved_at": chrono::Utc::now().to_rfc3339(),
+        });
+
+        self.add_document(path.clone(), content, metadata).await?;
+        Ok(path)
+    }
+
     pub async fn delete(&self, path_or_id: &str) -> Result<Option<MemoryDocument>> {
         let mut docs = self.docs.write().await;
         let removed = docs
@@ -3127,5 +3141,24 @@ mod tests {
         assert!(!is_likely_speaker("What"));
         assert!(!is_likely_speaker("She"));
         assert!(!is_likely_speaker("The"));
+    }
+
+    #[tokio::test]
+    async fn test_save_session_context() {
+        let docs = Arc::new(RwLock::new(Vec::new()));
+        let memory = QmdMemory::new(docs);
+
+        let session_id = "test-session-123";
+        let content = "This is a test session context. ".repeat(50);
+
+        let path = memory.save_session_context(session_id, content.clone()).await.unwrap();
+        assert_eq!(path, format!("sessions/{}/context", session_id));
+
+        let all_docs = memory.all_documents().await;
+        assert_eq!(all_docs.len(), 1);
+        assert_eq!(all_docs[0].path, path);
+        assert_eq!(all_docs[0].content, content);
+        assert_eq!(all_docs[0].metadata["session_id"], session_id);
+        assert_eq!(all_docs[0].metadata["type"], "session_context");
     }
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -96,47 +96,27 @@ impl Default for ShutdownState {
 /// Returns a handle to the task; dropping the handle does NOT cancel the task.
 pub async fn start_signal_handler(state: ShutdownState) {
     tokio::spawn(async move {
-        use tokio::signal::windows::ctrl_c;
-
         let mut shutdown_reason: Option<&'static str> = None;
 
         // Unix signals (SIGTERM / SIGINT)
         #[cfg(unix)]
         {
             use tokio::signal::unix::{signal, SignalKind};
-            let mut sigterm = match signal(SignalKind::terminate()) {
-                Ok(s) => s,
-                Err(e) => {
-                    error!("Failed to register SIGTERM handler: {}", e);
-                    return;
-                }
-            };
-            let mut sigint = match signal(SignalKind::interrupt()) {
-                Ok(s) => s,
-                Err(e) => {
-                    error!("Failed to register SIGINT handler: {}", e);
-                    return;
-                }
-            };
+            let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
+            let mut sigint = signal(SignalKind::interrupt()).expect("failed to register SIGINT handler");
 
             tokio::select! {
                 _ = sigterm.recv() => shutdown_reason = Some("SIGTERM"),
                 _ = sigint.recv() => shutdown_reason = Some("SIGINT"),
+                _ = tokio::signal::ctrl_c() => shutdown_reason = Some("Ctrl+C"),
             }
         }
 
-        // Windows console events
-        #[cfg(windows)]
+        // Non-Unix platform support (Windows)
+        #[cfg(not(unix))]
         {
-            let ctrl_events = async {
-                let mut rx = ctrl_c().expect("failed to subscribe to Ctrl+C");
-                rx.recv().await
-            };
-
-            let reason = ctrl_events.await;
-            match reason {
-                Some(()) => shutdown_reason = Some("Ctrl+C / console close"),
-                None => {}
+            if tokio::signal::ctrl_c().await.is_ok() {
+                shutdown_reason = Some("Ctrl+C");
             }
         }
 


### PR DESCRIPTION
This PR adds the `session_save` tool to Xavier2, enabling agents to persist full session context before a context window overflow.

### Key Changes:
- **Memory Layer**: Added `save_session_context` to `QmdMemory` in `src/memory/qmd_memory.rs`. It saves content to a predictable path with metadata including the session ID and a timestamp.
- **CLI/API**: 
    - Added a POST `/session/save` endpoint to the HTTP server.
    - Added the `session_save` tool to the MCP server implementation in `src/cli.rs`.
- **Security**: 
    - Implemented `session_id` validation to prevent path traversal (blocking `/`, `\`, and `..`).
    - Added security scanning for the saved content in both HTTP and MCP handlers.
- **Fixes**: Corrected an unrelated signal handling regression in `src/server/http.rs` that was preventing compilation on non-Windows systems and would have broken graceful shutdown.

### Verification:
- Added a unit test `test_save_session_context` in `src/memory/qmd_memory.rs`.
- Verified compilation with `cargo check --bin xavier2`.
- Verified MCP tool registration and HTTP route registration in `src/cli.rs`.

Fixes #47

---
*PR created automatically by Jules for task [4498603371851627294](https://jules.google.com/task/4498603371851627294) started by @iberi22*