### PR TITLE
[feat] FASE 2 - Save/Retrieve Verification Automation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod telegram;
 pub mod tools;
 pub mod ui;
 pub mod utils;
+pub mod verification;
 pub mod workspace;
 
 // Hexagonal architecture modules

--- a/src/memory/qmd_memory.rs
+++ b/src/memory/qmd_memory.rs
@@ -219,6 +219,31 @@ impl QmdMemory {
         Ok(())
     }
 
+    pub async fn add_with_verification(
+        &self,
+        workspace_ctx: crate::workspace::WorkspaceContext,
+        doc: MemoryDocument,
+    ) -> Result<()> {
+        let content = doc.content.clone();
+        let path = doc.path.clone();
+        self.add(doc).await?;
+
+        // Trigger verification asynchronously
+        let memory = self.clone();
+        tokio::spawn(async move {
+            let result = crate::verification::verify_save(&memory, &content).await;
+            crate::verification::auto_verifier::process_verification(
+                workspace_ctx,
+                path,
+                content,
+                result,
+            )
+            .await;
+        });
+
+        Ok(())
+    }
+
     pub async fn search(&self, query_text: &str, limit: usize) -> Result<Vec<MemoryDocument>> {
         self.search_filtered(query_text, limit, None).await
     }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -96,8 +96,6 @@ impl Default for ShutdownState {
 /// Returns a handle to the task; dropping the handle does NOT cancel the task.
 pub async fn start_signal_handler(state: ShutdownState) {
     tokio::spawn(async move {
-        use tokio::signal::windows::ctrl_c;
-
         let mut shutdown_reason: Option<&'static str> = None;
 
         // Unix signals (SIGTERM / SIGINT)
@@ -128,6 +126,7 @@ pub async fn start_signal_handler(state: ShutdownState) {
         // Windows console events
         #[cfg(windows)]
         {
+            use tokio::signal::windows::ctrl_c;
             let ctrl_events = async {
                 let mut rx = ctrl_c().expect("failed to subscribe to Ctrl+C");
                 rx.recv().await
@@ -790,19 +789,45 @@ pub async fn memory_add(
         }));
     }
 
+    let metadata_normalized = match crate::memory::schema::normalize_metadata(
+        &path,
+        metadata.clone(),
+        &workspace.workspace_id,
+        Some(typed.clone()),
+    ) {
+        Ok(m) => m,
+        Err(e) => {
+            return Json(serde_json::json!({
+                "status": "error",
+                "message": e.to_string(),
+                "workspace_id": workspace.workspace_id,
+            }))
+        }
+    };
+
+    let doc = crate::memory::qmd_memory::MemoryDocument {
+        id: Some(ulid::Ulid::new().to_string()),
+        path: path.clone(),
+        content: content.clone(),
+        metadata: metadata_normalized,
+        content_vector: content_vector.clone(),
+        embedding: content_vector.unwrap_or_default(),
+    };
+
+    let doc_id = doc.id.clone().unwrap_or_default();
+
     match workspace
         .workspace
-        .ingest_typed(
-            path,
-            content.clone(),
-            metadata.clone(),
-            Some(typed),
-            content_vector,
-            false,
-        )
+        .memory
+        .add_with_verification(workspace.clone(), doc)
         .await
     {
-        Ok(_) => {}
+        Ok(_) => {
+            workspace
+                .workspace
+                .index_memory_layers(&doc_id, &content, &metadata)
+                .await;
+        }
         Err(error) => {
             tracing::error!(%error, workspace_id = %workspace.workspace_id, "failed to add memory document");
             return Json(serde_json::json!({
@@ -817,6 +842,7 @@ pub async fn memory_add(
         "status": "ok",
         "message": "Document added to memory",
         "workspace_id": workspace.workspace_id,
+        "id": doc_id,
     }))
 }
 

--- a/src/server/v1_api.rs
+++ b/src/server/v1_api.rs
@@ -136,34 +136,54 @@ pub async fn v1_memories_add(
         }));
     }
 
+    let doc_id = ulid::Ulid::new().to_string();
+    let metadata_normalized = match crate::memory::schema::normalize_metadata(
+        &path,
+        meta,
+        &workspace.workspace_id,
+        Some(TypedMemoryPayload {
+            kind: payload.kind,
+            evidence_kind: payload.evidence_kind,
+            namespace: namespace.clone(),
+            provenance: payload.provenance.clone(),
+        }),
+    ) {
+        Ok(m) => m,
+        Err(e) => {
+            return Json(serde_json::json!({
+                "status": "error",
+                "message": e.to_string(),
+            }))
+        }
+    };
+
+    let doc = crate::memory::qmd_memory::MemoryDocument {
+        id: Some(doc_id.clone()),
+        path: path.clone(),
+        content: content.clone(),
+        metadata: metadata_normalized,
+        content_vector: Some(Vec::new()),
+        embedding: Vec::new(),
+    };
+
     match workspace
         .workspace
         .memory
-        .add_document_typed(
-            path,
-            content,
-            meta,
-            Some(TypedMemoryPayload {
-                kind: payload.kind,
-                evidence_kind: payload.evidence_kind,
-                namespace,
-                provenance: payload.provenance,
-            }),
-        )
+        .add_with_verification(workspace.clone(), doc)
         .await
     {
-        Ok(id) => {
+        Ok(_) => {
             if let Err(error) = workspace
                 .workspace
-                .index_memory_entities(&id, &content_for_graph, &meta_for_graph)
+                .index_memory_entities(&doc_id, &content_for_graph, &meta_for_graph)
                 .await
             {
-                tracing::warn!(%error, memory_id = %id, "failed to index entity graph from v1 add");
+                tracing::warn!(%error, memory_id = %doc_id, "failed to index entity graph from v1 add");
             }
             Json(serde_json::json!({
                 "status": "ok",
                 "message": "Memory added successfully",
-                "id": id,
+                "id": doc_id,
             }))
         }
         Err(e) => Json(serde_json::json!({

--- a/src/verification/auto_verifier.rs
+++ b/src/verification/auto_verifier.rs
@@ -1,0 +1,164 @@
+use serde::{Deserialize, Serialize};
+use std::time::Instant;
+use crate::memory::qmd_memory::QmdMemory;
+use crate::workspace::WorkspaceContext;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationResult {
+    pub save_ok: bool,
+    pub latency_ms: u64,
+    pub match_score: f32,  // 0.0 to 1.0
+    pub content_identical: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct VerificationMetrics {
+    pub total_saves: u64,
+    pub successful_saves: u64,
+    pub save_ok_rate: f32,
+    pub avg_latency_ms: f32,
+    pub match_score_avg: f32,
+}
+
+static METRICS: Lazy<Arc<RwLock<HashMap<String, VerificationMetrics>>>> =
+    Lazy::new(|| Arc::new(RwLock::new(HashMap::new())));
+
+pub async fn verify_save(memory: &QmdMemory, content: &str) -> VerificationResult {
+    let start = Instant::now();
+
+    // 1. Immediately retrieve with same content
+    let search_results = match memory.search(content, 1).await {
+        Ok(results) => results,
+        Err(_) => return VerificationResult {
+            save_ok: false,
+            latency_ms: start.elapsed().as_millis() as u64,
+            match_score: 0.0,
+            content_identical: false,
+        },
+    };
+
+    let latency_ms = start.elapsed().as_millis() as u64;
+
+    if search_results.is_empty() {
+        return VerificationResult {
+            save_ok: false,
+            latency_ms,
+            match_score: 0.0,
+            content_identical: false,
+        };
+    }
+
+    let retrieved = &search_results[0];
+    let content_identical = retrieved.content == content;
+
+    let match_score = calculate_similarity(content, &retrieved.content);
+
+    VerificationResult {
+        save_ok: true,
+        latency_ms,
+        match_score,
+        content_identical,
+    }
+}
+
+pub async fn process_verification(workspace_ctx: WorkspaceContext, path: String, content: String, result: VerificationResult) {
+    // Avoid infinite recursion for metrics paths
+    if path.starts_with("metrics/verification/") {
+        return;
+    }
+
+    let workspace_id = workspace_ctx.workspace_id.clone();
+
+    // 1. Update in-memory metrics
+    let mut all_metrics = METRICS.write().await;
+    let metrics = all_metrics.entry(workspace_id.clone()).or_insert_with(VerificationMetrics::default);
+
+    metrics.total_saves += 1;
+    if result.save_ok {
+        metrics.successful_saves += 1;
+    }
+
+    metrics.save_ok_rate = metrics.successful_saves as f32 / metrics.total_saves as f32;
+    metrics.avg_latency_ms = (metrics.avg_latency_ms * (metrics.total_saves as f32 - 1.0) + result.latency_ms as f32) / metrics.total_saves as f32;
+    metrics.match_score_avg = (metrics.match_score_avg * (metrics.total_saves as f32 - 1.0) + result.match_score) / metrics.total_saves as f32;
+
+    let current_metrics = metrics.clone();
+    drop(all_metrics);
+
+    // 2. Log result to feedback/xavier2/ (Async I/O)
+    let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%S").to_string();
+    let log_dir = std::path::Path::new("feedback/xavier2");
+
+    if let Err(e) = tokio::fs::create_dir_all(log_dir).await {
+        tracing::error!("Failed to create feedback directory: {}", e);
+    } else {
+        let log_file = log_dir.join(format!("verification-{}-{}.json", workspace_id, timestamp));
+        let log_data = serde_json::json!({
+            "workspace_id": workspace_id,
+            "path": path,
+            "content_hash": crate::utils::crypto::sha256_hex(content.as_bytes()),
+            "result": result,
+            "metrics_snapshot": current_metrics
+        });
+        if let Ok(content_str) = serde_json::to_string_pretty(&log_data) {
+            if let Err(e) = tokio::fs::write(log_file, content_str).await {
+                tracing::error!("Failed to write verification log: {}", e);
+            }
+        }
+    }
+
+    // 3. Persist metrics in Xavier2 at metrics/verification/{date}
+    let metrics_path = format!("metrics/verification/{}", date);
+    let _ = workspace_ctx.workspace.memory.add_document_typed(
+        metrics_path,
+        serde_json::to_string(&current_metrics).unwrap_or_default(),
+        serde_json::json!({
+            "category": "metrics",
+            "type": "verification",
+            "date": date,
+            "workspace_id": workspace_id
+        }),
+        None
+    ).await;
+
+    // 4. Alert on Degradation
+    if current_metrics.save_ok_rate < 0.95 || current_metrics.match_score_avg < 0.85 {
+        tracing::warn!("REPORT TO CORTEX: Performance degradation detected in workspace {}", workspace_id);
+        let alert_file = log_dir.join(format!("alert-{}-{}.json", workspace_id, date));
+        let alert_data = serde_json::json!({
+            "date": date,
+            "workspace_id": workspace_id,
+            "message": "Performance degradation detected",
+            "metrics": current_metrics
+        });
+        if let Ok(content_str) = serde_json::to_string_pretty(&alert_data) {
+            let _ = tokio::fs::write(alert_file, content_str).await;
+        }
+    }
+}
+
+fn calculate_similarity(original: &str, retrieved: &str) -> f32 {
+    if original == retrieved {
+        return 1.0;
+    }
+    if original.is_empty() || retrieved.is_empty() {
+        return 0.0;
+    }
+
+    let original_words: std::collections::HashSet<_> = original.split_whitespace().collect();
+    let retrieved_words: std::collections::HashSet<_> = retrieved.split_whitespace().collect();
+
+    let intersection = original_words.intersection(&retrieved_words).count();
+    let union = original_words.union(&retrieved_words).count();
+
+    if union == 0 {
+        return 0.0;
+    }
+
+    intersection as f32 / union as f32
+}

--- a/src/verification/mod.rs
+++ b/src/verification/mod.rs
@@ -1,0 +1,3 @@
+pub mod auto_verifier;
+
+pub use auto_verifier::{verify_save, VerificationResult};

--- a/tests/verification_test.rs
+++ b/tests/verification_test.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use xavier2::memory::qmd_memory::{MemoryDocument, QmdMemory};
+use xavier2::verification::verify_save;
+use xavier2::workspace::{WorkspaceConfig, WorkspaceState};
+use xavier2::agents::RuntimeConfig;
+
+#[tokio::test]
+async fn test_verify_save_success() {
+    let memory = QmdMemory::new(Arc::new(RwLock::new(Vec::new())));
+    let content = "This is a test memory for verification automation.";
+    let path = "test/verify/1";
+
+    // Add the document
+    memory.add(MemoryDocument {
+        id: Some("test-id".to_string()),
+        path: path.to_string(),
+        content: content.to_string(),
+        metadata: serde_json::json!({}),
+        content_vector: Some(Vec::new()),
+        embedding: Vec::new(),
+    }).await.unwrap();
+
+    // Verify
+    let result = verify_save(&memory, content).await;
+
+    assert!(result.save_ok);
+    assert!(result.content_identical);
+    assert!(result.match_score > 0.9);
+}
+
+#[tokio::test]
+async fn test_verify_save_failure_not_found() {
+    let memory = QmdMemory::new(Arc::new(RwLock::new(Vec::new())));
+    let content = "This document is not in memory.";
+
+    // Verify without adding
+    let result = verify_save(&memory, content).await;
+
+    assert!(!result.save_ok);
+    assert_eq!(result.match_score, 0.0);
+}
+
+#[tokio::test]
+async fn test_process_verification_creates_files() {
+    let root = std::env::temp_dir().join(format!("xavier2-test-verify-{}", ulid::Ulid::new()));
+    let config = WorkspaceConfig {
+        id: "test-verify".to_string(),
+        token: "token".to_string(),
+        plan: xavier2::workspace::PlanTier::Personal,
+        memory_backend: xavier2::memory::surreal_store::MemoryBackend::Memory,
+        storage_limit_bytes: None,
+        request_limit: None,
+        request_unit_limit: None,
+        embedding_provider_mode: xavier2::workspace::EmbeddingProviderMode::BringYourOwn,
+        managed_google_embeddings: false,
+        sync_policy: xavier2::workspace::SyncPolicy::LocalOnly,
+    };
+
+    let workspace = WorkspaceState::new(config, RuntimeConfig::default(), &root)
+        .await
+        .unwrap();
+
+    let workspace_ctx = xavier2::workspace::WorkspaceContext {
+        workspace_id: "test-verify".to_string(),
+        workspace: Arc::new(workspace),
+    };
+
+    let result = xavier2::verification::VerificationResult {
+        save_ok: true,
+        latency_ms: 10,
+        match_score: 1.0,
+        content_identical: true,
+    };
+
+    xavier2::verification::auto_verifier::process_verification(
+        workspace_ctx,
+        "test/path".to_string(),
+        "test content".to_string(),
+        result,
+    ).await;
+
+    // Check if log file exists
+    let log_dir = std::path::Path::new("feedback/xavier2");
+    assert!(log_dir.exists());
+
+    let entries = std::fs::read_dir(log_dir).unwrap();
+    let count = entries.filter_map(|e| e.ok()).count();
+    assert!(count > 0);
+}


### PR DESCRIPTION
This PR implements Phase 2 of the Save/Retrieve Verification Automation, as specified in the feature request.

### Key Changes:
- **Auto-Verifier Module**: A new module in `src/verification/` that handles the save/retrieve verification cycle.
- **Metrics Collection**: Automatically calculates and aggregates `save_ok_rate`, `avg_latency_ms`, and `match_score_avg`. Metrics are persisted as memory documents for dashboarding.
- **Alerting**: Generates JSON alerts when performance thresholds are breached.
- **System Integration**: Hooked the verifier into `POST /v1/memories` and `POST /memory/add` to run asynchronously after successful saves.
- **Robustness**: 
    - Used asynchronous file I/O to avoid blocking the Tokio runtime.
    - Added loop prevention to skip verification for internal metrics storage.
    - Improved alert naming to include workspace IDs.
- **Testing**: Included a new integration test suite to validate the full verification cycle.

Priority: CRITICAL
Ref: FASE 2 - Save/Retrieve Verification Automation

Fixes #56

---
*PR created automatically by Jules for task [12383945558626113791](https://jules.google.com/task/12383945558626113791) started by @iberi22*