### PR TITLE
Implement Real-time WebSocket Streaming Endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -419,8 +420,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -6152,7 +6155,7 @@ dependencies = [
  "surrealdb-types",
  "surrealdb-types-derive",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tokio-tungstenite-wasm",
  "tokio-util",
  "tracing",
@@ -6703,6 +6706,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -6713,8 +6728,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -6731,7 +6758,7 @@ dependencies = [
  "js-sys",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -7024,6 +7051,23 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -7040,6 +7084,22 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8303,6 +8363,7 @@ dependencies = [
  "egui",
  "egui_extras",
  "flate2",
+ "futures-util",
  "generic-array 0.14.7",
  "hex",
  "hmac",
@@ -8329,6 +8390,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite 0.26.2",
  "tower",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ ulid = "1.1"
 uuid = { version = "1.8", features = ["v4"] }
 
 # HTTP Server
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
 
 # Logging
@@ -123,11 +123,13 @@ hmac = "0.12"
 http-body-util = "0.1"
 
 [dev-dependencies]
-proptest = "1.6.0"
-tempfile = "3.10"
+proptest = "1.11.0"
+tempfile = "3.27.0"
 criterion = "0.5"
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
+tokio-tungstenite = "0.26"
+futures-util = "0.3"
 
 [[bin]]
 name = "xavier2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,7 @@ use tracing::info;
 use xavier2::adapters::inbound::http::routes::{
     sync_check_handler, time_metric_handler, verify_save_handler,
 };
+use xavier2::server::http::ws_events_handler;
 use xavier2::adapters::outbound::http_health_adapter::HttpHealthAdapter;
 use xavier2::app::qmd_memory_adapter::QmdMemoryAdapter;
 use xavier2::coordination::SimpleAgentRegistry;
@@ -110,7 +111,10 @@ async fn start_http_server(port: u16) -> Result<()> {
     info!("Starting Xavier2 HTTP server on port {}", port);
 
     // Initialize the memory store
-    let store = Arc::new(VecSqliteMemoryStore::from_env().await?);
+    let mut store_inner = VecSqliteMemoryStore::from_env().await?;
+    let (event_tx, _) = tokio::sync::broadcast::channel(100);
+    store_inner.set_event_tx(event_tx);
+    let store = Arc::new(store_inner);
     let workspace_id =
         std::env::var("XAVIER2_DEFAULT_WORKSPACE_ID").unwrap_or_else(|_| "default".to_string());
     let durable_state = store.load_workspace_state(&workspace_id).await?;
@@ -210,6 +214,7 @@ async fn start_http_server(port: u16) -> Result<()> {
             "/xavier2/agents/{id}/unregister",
             delete(agent_unregister_handler),
         )
+        .route("/xavier2/events/stream", get(ws_events_handler))
         .route("/xavier2/sync/check", post(sync_check_handler))
         .route("/xavier2/sync/check", get(sync_check_handler))
         .route("/xavier2/verify/save", post(verify_save_handler))

--- a/src/memory/sqlite_vec_store.rs
+++ b/src/memory/sqlite_vec_store.rs
@@ -17,6 +17,7 @@ use rusqlite::ffi::sqlite3_auto_extension;
 use rusqlite::{params, Connection};
 use sha2::{Digest, Sha256};
 use tokio::fs;
+use tokio::sync::broadcast;
 
 use crate::checkpoint::Checkpoint;
 use crate::memory::belief_graph::BeliefRelation;
@@ -107,6 +108,7 @@ impl VecSqliteStoreConfig {
 pub struct VecSqliteMemoryStore {
     conn: Arc<Mutex<Connection>>,
     config: VecSqliteStoreConfig,
+    event_tx: Option<broadcast::Sender<crate::server::events::RealtimeEvent>>,
 }
 
 impl VecSqliteMemoryStore {
@@ -117,6 +119,10 @@ impl VecSqliteMemoryStore {
 
     pub async fn from_env() -> Result<Self> {
         Self::new(VecSqliteStoreConfig::from_env()).await
+    }
+
+    pub fn set_event_tx(&mut self, tx: broadcast::Sender<crate::server::events::RealtimeEvent>) {
+        self.event_tx = Some(tx);
     }
 
     pub async fn new(config: VecSqliteStoreConfig) -> Result<Self> {
@@ -154,6 +160,7 @@ impl VecSqliteMemoryStore {
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
             config,
+            event_tx: None,
         })
     }
 
@@ -1039,6 +1046,7 @@ impl VecSqliteMemoryStore {
     }
 
     fn append_timeline_event(
+        &self,
         conn: &Connection,
         workspace_id: &str,
         record: &MemoryRecord,
@@ -1167,6 +1175,31 @@ impl VecSqliteMemoryStore {
                     serde_json::json!({"chain": "timeline"}).to_string()
                 ],
             )?;
+        }
+
+        // Broadcast event
+        if let Some(tx) = &self.event_tx {
+            let project_id = record
+                .metadata
+                .get("namespace")
+                .and_then(|ns| ns.get("project"))
+                .and_then(|p| p.as_str())
+                .or_else(|| record.metadata.get("project").and_then(|p| p.as_str()))
+                .map(|s| s.to_string());
+
+            let _ = tx.send(crate::server::events::RealtimeEvent {
+                workspace_id: workspace_id.to_string(),
+                event_id: event.id,
+                agent_id: event.agent_id,
+                project_id,
+                event_type: event.operation,
+                timestamp: event.timestamp,
+                payload: serde_json::json!({
+                    "memory_id": record.id,
+                    "path": record.path,
+                    "revision": record.revision,
+                }),
+            });
         }
 
         Ok(())
@@ -1678,7 +1711,7 @@ impl MemoryStore for VecSqliteMemoryStore {
                 "INSERT INTO memory_chain (id, prev_hash, content_hash) VALUES (?, ?, ?)",
                 params![chain_id, prev_hash, content_hash],
             )?;
-            Self::append_timeline_event(&conn, &record.workspace_id, &record)?;
+            self.append_timeline_event(&conn, &record.workspace_id, &record)?;
         }
 
         // Store vector in sqlite-vec virtual table

--- a/src/server/events.rs
+++ b/src/server/events.rs
@@ -1,0 +1,52 @@
+//! Real-time event types for Xavier2 WebSocket streaming.
+
+use serde::{Deserialize, Serialize};
+
+/// Internal event broadcasted across the system.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealtimeEvent {
+    pub workspace_id: String,
+    pub event_id: String,
+    pub agent_id: String,
+    pub project_id: Option<String>,
+    pub event_type: String,
+    pub timestamp: String,
+    pub payload: serde_json::Value,
+}
+
+/// Messages sent from the client to the server via WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WsMessage {
+    /// Subscribe to events matching the given filters.
+    /// If multiple filters are provided, they are combined with AND logic.
+    Subscribe {
+        #[serde(default)]
+        agent_id: Option<String>,
+        #[serde(default)]
+        project_id: Option<String>,
+        #[serde(default)]
+        event_type: Option<String>,
+    },
+    /// Unsubscribe from events matching the given filters.
+    Unsubscribe {
+        #[serde(default)]
+        agent_id: Option<String>,
+        #[serde(default)]
+        project_id: Option<String>,
+        #[serde(default)]
+        event_type: Option<String>,
+    },
+}
+
+/// Messages sent from the server to the client via WebSocket.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WsEvent {
+    /// A real-time event matching the client's subscriptions.
+    Event(RealtimeEvent),
+    /// Confirmation that a subscription/unsubscription was successful.
+    SubscriptionConfirmed,
+    /// An error message.
+    Error { message: String },
+}

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -1,6 +1,10 @@
 //! HTTP handlers for the minimal Xavier2 vertical slice.
 
-use axum::{extract::State, response::IntoResponse, Extension, Json};
+use axum::{
+    extract::{ws::Message, ws::WebSocket, State, WebSocketUpgrade},
+    response::IntoResponse,
+    Extension, Json,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -9,6 +13,7 @@ use tracing::{error, info};
 
 use crate::{
     agents::provider::ModelProviderClient,
+    server::events::{WsEvent, WsMessage},
     agents::runtime::System3Mode,
     consistency::regularization::{CoherenceReport, RetentionRegularizer},
     consolidation::ConsolidationTask,
@@ -80,6 +85,118 @@ impl ShutdownState {
         } else {
             // We store the timestamp in the atomic as seconds-since-epoch.
             val
+        }
+    }
+}
+
+// ============================================================
+// Real-time Event Streaming (WebSocket)
+// ============================================================
+
+#[derive(Debug, Default, Clone)]
+struct WsSubscriptions {
+    agent_ids: std::collections::HashSet<String>,
+    project_ids: std::collections::HashSet<String>,
+    event_types: std::collections::HashSet<String>,
+}
+
+impl WsSubscriptions {
+    fn matches(&self, event: &crate::server::events::RealtimeEvent) -> bool {
+        // If no subscriptions, match nothing
+        if self.agent_ids.is_empty() && self.project_ids.is_empty() && self.event_types.is_empty() {
+            return false;
+        }
+
+        if !self.agent_ids.is_empty() && !self.agent_ids.contains(&event.agent_id) {
+            return false;
+        }
+
+        if !self.project_ids.is_empty() {
+            match &event.project_id {
+                Some(p) if self.project_ids.contains(p) => {}
+                _ => return false,
+            }
+        }
+
+        if !self.event_types.is_empty() && !self.event_types.contains(&event.event_type) {
+            return false;
+        }
+
+        true
+    }
+}
+
+pub async fn ws_events_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    let rx = state
+        .workspace_registry
+        .default_context_sync()
+        .and_then(|ctx| {
+            ctx.workspace
+                .durable_store()
+                .downcast_ref::<VecSqliteMemoryStore>()
+        })
+        .and_then(|s| s.event_tx.as_ref())
+        .map(|tx: &broadcast::Sender<crate::server::events::RealtimeEvent>| tx.subscribe());
+
+    ws.on_upgrade(move |socket| handle_ws_socket(socket, rx))
+}
+
+async fn handle_ws_socket(
+    mut socket: WebSocket,
+    mut event_rx: Option<broadcast::Receiver<crate::server::events::RealtimeEvent>>,
+) {
+    let mut subscriptions = WsSubscriptions::default();
+
+    loop {
+        tokio::select! {
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        if let Ok(ws_msg) = serde_json::from_str::<WsMessage>(&text) {
+                            match ws_msg {
+                                WsMessage::Subscribe { agent_id, project_id, event_type } => {
+                                    if let Some(id) = agent_id { subscriptions.agent_ids.insert(id); }
+                                    if let Some(id) = project_id { subscriptions.project_ids.insert(id); }
+                                    if let Some(id) = event_type { subscriptions.event_types.insert(id); }
+
+                                    let _ = socket.send(Message::Text(
+                                        serde_json::to_string(&WsEvent::SubscriptionConfirmed).unwrap_or_default()
+                                    )).await;
+                                }
+                                WsMessage::Unsubscribe { agent_id, project_id, event_type } => {
+                                    if let Some(id) = agent_id { subscriptions.agent_ids.remove(&id); }
+                                    if let Some(id) = project_id { subscriptions.project_ids.remove(&id); }
+                                    if let Some(id) = event_type { subscriptions.event_types.remove(&id); }
+
+                                    let _ = socket.send(Message::Text(
+                                        serde_json::to_string(&WsEvent::SubscriptionConfirmed).unwrap_or_default()
+                                    )).await;
+                                }
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => break,
+                    _ => {}
+                }
+            }
+            event_res = async {
+                if let Some(rx) = &mut event_rx {
+                    rx.recv().await.ok()
+                } else {
+                    None
+                }
+            } => {
+                if let Some(event) = event_res {
+                    if subscriptions.matches(&event) {
+                        let _ = socket.send(Message::Text(
+                            serde_json::to_string(&WsEvent::Event(event)).unwrap_or_default()
+                        )).await;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,6 @@
 //! Server modules for AgentRAG/Xavier2
 
+pub mod events;
 pub mod http;
 pub mod mcp_server;
 pub mod mcp_stdio;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1329,6 +1329,27 @@ impl WorkspaceRegistry {
             })
     }
 
+    pub fn default_context_sync(&self) -> Option<WorkspaceContext> {
+        let preferred_id =
+            std::env::var("XAVIER2_DEFAULT_WORKSPACE_ID").unwrap_or_else(|_| "default".to_string());
+        let workspaces = self.workspaces.blocking_read();
+
+        if let Some(workspace) = workspaces.get(&preferred_id).cloned() {
+            return Some(WorkspaceContext {
+                workspace_id: preferred_id,
+                workspace,
+            });
+        }
+
+        workspaces
+            .iter()
+            .next()
+            .map(|(id, workspace)| WorkspaceContext {
+                workspace_id: id.clone(),
+                workspace: workspace.clone(),
+            })
+    }
+
     pub async fn default_from_env(runtime_config: RuntimeConfig) -> Result<Self> {
         let registry = Self::new();
         let config = WorkspaceConfig::from_env();

--- a/tests/websocket_events.rs
+++ b/tests/websocket_events.rs
@@ -1,0 +1,119 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use futures_util::{SinkExt, StreamExt};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+use xavier2::memory::sqlite_vec_store::{VecSqliteMemoryStore, VecSqliteStoreConfig};
+use xavier2::server::http::{ws_events_handler, add_handler};
+use xavier2::server::events::{WsEvent, WsMessage};
+use xavier2::AppState;
+use xavier2::workspace::{WorkspaceRegistry, WorkspaceState, WorkspaceConfig};
+use xavier2::agents::RuntimeConfig;
+use xavier2::memory::file_indexer::{FileIndexer, FileIndexerConfig};
+use xavier2::app::security_service::SecurityService;
+use xavier2::adapters::outbound::vec::pattern_adapter::PatternAdapter;
+use xavier2::ports::inbound::MemoryQueryPort;
+use xavier2::app::qmd_memory_adapter::QmdMemoryAdapter;
+use xavier2::memory::qmd_memory::{MemoryDocument, QmdMemory};
+use xavier2::memory::surreal_store::MemoryStore;
+use xavier2::coordination::SimpleAgentRegistry;
+use tokio::sync::RwLock;
+
+#[tokio::test]
+async fn test_websocket_streaming() {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("test_ws.db");
+
+    let mut store_inner = VecSqliteMemoryStore::new(VecSqliteStoreConfig {
+        path: db_path,
+        embedding_dimensions: 3,
+    }).await.unwrap();
+
+    let (event_tx, _) = tokio::sync::broadcast::channel(100);
+    store_inner.set_event_tx(event_tx);
+    let store = Arc::new(store_inner);
+
+    let workspace_id = "test_ws_workspace";
+    let memory = Arc::new(QmdMemory::new_with_workspace(Arc::new(RwLock::new(vec![])), workspace_id.to_string()));
+    memory.set_store(store.clone() as Arc<dyn MemoryStore>).await;
+    memory.init().await.unwrap();
+    let memory_port = Arc::new(QmdMemoryAdapter::new(Arc::clone(&memory))) as Arc<dyn MemoryQueryPort>;
+
+    let code_db_path = temp.path().join("code_graph.db");
+    let code_db = Arc::new(code_graph::db::CodeGraphDB::new(&code_db_path).unwrap());
+    let code_indexer = Arc::new(code_graph::indexer::Indexer::new(Arc::clone(&code_db)));
+    let code_query = Arc::new(code_graph::query::QueryEngine::new(Arc::clone(&code_db)));
+
+    let state = xavier2::cli::CliState {
+        memory: memory_port,
+        store: store.clone(),
+        workspace_id: workspace_id.to_string(),
+        code_db,
+        code_indexer,
+        code_query,
+        security: Arc::new(SecurityService::new()),
+        time_store: None,
+        agent_registry: Arc::new(SimpleAgentRegistry::new()),
+    };
+
+    let app = Router::new()
+        .route("/memory/add", post(add_handler))
+        .route("/xavier2/events/stream", get(ws_events_handler))
+        .with_state(state);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let ws_url = format!("ws://{}/xavier2/events/stream", addr);
+    let (mut ws_stream, _) = connect_async(ws_url).await.unwrap();
+
+    // Subscribe to events
+    let sub_msg = WsMessage::Subscribe {
+        agent_id: Some("test_agent".to_string()),
+        project_id: None,
+        event_type: None,
+    };
+    ws_stream.send(Message::Text(serde_json::to_string(&sub_msg).unwrap().into())).await.unwrap();
+
+    let msg = ws_stream.next().await.unwrap().unwrap();
+    let conf: WsEvent = serde_json::from_str(msg.to_text().unwrap()).unwrap();
+    assert!(matches!(conf, WsEvent::SubscriptionConfirmed));
+
+    // Add a memory record via HTTP
+    let client = reqwest::Client::new();
+    let add_res = client.post(format!("http://{}/memory/add", addr))
+        .json(&serde_json::json!({
+            "content": "Hello real-time world",
+            "metadata": {
+                "_audit": {
+                    "agent_id": "test_agent",
+                    "operation": "memory.add"
+                }
+            }
+        }))
+        .send()
+        .await.unwrap();
+
+    assert_eq!(add_res.status(), StatusCode::OK);
+
+    // Wait for the event
+    let msg = ws_stream.next().await.unwrap().unwrap();
+    let event: WsEvent = serde_json::from_str(msg.to_text().unwrap()).unwrap();
+
+    if let WsEvent::Event(e) = event {
+        assert_eq!(e.agent_id, "test_agent");
+        assert_eq!(e.event_type, "memory.add");
+        assert!(e.payload["path"].as_str().is_some());
+    } else {
+        panic!("Expected WsEvent::Event, got {:?}", event);
+    }
+}


### PR DESCRIPTION
Implemented a native WebSocket endpoint for real-time event streaming in Xavier2. This includes:
1. A new `events` module for protocol definitions.
2. Integration with `VecSqliteMemoryStore` to broadcast events on memory additions.
3. A WebSocket handler supporting subscriptions and filtering by agent_id, project_id, and event_type.
4. Integration with the CLI-driven HTTP server.
5. Initial integration test suite.

Fixes #138

---
*PR created automatically by Jules for task [13076973627155088088](https://jules.google.com/task/13076973627155088088) started by @iberi22*