### PR TITLE
Mitigate SSRF risk in verify_save_handler and internal sync tasks

### DIFF
--- a/src/adapters/inbound/http/routes.rs
+++ b/src/adapters/inbound/http/routes.rs
@@ -131,6 +131,17 @@ pub async fn verify_save_handler(
 
     let xavier2_url =
         std::env::var("XAVIER2_URL").unwrap_or_else(|_| "http://localhost:8006".to_string());
+
+    // Validate internal URL to prevent SSRF
+    if let Err(e) = crate::security::url_validator::validate_internal_url(&xavier2_url) {
+        tracing::error!("Internal URL validation failed: {}", e);
+        return Json(VerifySaveResponse {
+            save_ok: false,
+            latency_ms: start.elapsed().as_millis() as u64,
+            match_score: 0.0,
+        });
+    }
+
     let auth_token = std::env::var("X-CORTEX-TOKEN").unwrap_or_else(|_| "dev-token".to_string());
 
     let client = reqwest::Client::new();

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -8,6 +8,7 @@ pub mod detections;
 pub mod layers;
 pub mod prompt_guard;
 pub mod scanner;
+pub mod url_validator;
 
 pub use anticipator::{Anticipator, AnticipatorConfig};
 pub use detections::{ScanResult as AnticipatorScanResult, Severity, Threat, ThreatCategory};

--- a/src/security/url_validator.rs
+++ b/src/security/url_validator.rs
@@ -1,0 +1,99 @@
+use reqwest::Url;
+use std::net::IpAddr;
+
+/// Validates a URL intended for internal Xavier2 communication.
+/// Prevents SSRF by blocking access to sensitive metadata services and
+/// ensuring the URL matches an optional allowlist.
+pub fn validate_internal_url(url_str: &str) -> Result<Url, String> {
+    let url = Url::parse(url_str).map_err(|e| format!("Invalid URL format: {}", e))?;
+
+    // 1. Block non-HTTP/HTTPS schemes
+    match url.scheme() {
+        "http" | "https" => {}
+        _ => return Err(format!("Unsupported scheme: {}", url.scheme())),
+    }
+
+    // 2. Validate Host
+    let host = url.host_str().ok_or("URL must have a host")?;
+
+    // 3. Block known metadata services
+    let forbidden_hosts = [
+        "169.254.169.254",
+        "metadata.google.internal",
+        "metadata",
+        "instance-data",
+        "100.100.100.200", // Alibaba Cloud
+    ];
+
+    if forbidden_hosts.iter().any(|&h| host.eq_ignore_ascii_case(h)) {
+        return Err(format!("Forbidden host detected: {}", host));
+    }
+
+    // 4. IP-based validation for private/link-local addresses
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if ip.is_loopback() {
+            // Allow loopback for local development if not explicitly forbidden
+            // but we might want to toggle this via env.
+        } else if ip.is_link_local() {
+            return Err("Link-local addresses are forbidden".to_string());
+        } else if ip.is_multicast() {
+            return Err("Multicast addresses are forbidden".to_string());
+        }
+    }
+
+    // 5. Allowlist validation (optional)
+    if let Ok(allowlist) = std::env::var("XAVIER2_ALLOWED_DOMAINS") {
+        let domains: Vec<&str> = allowlist.split(',').collect();
+        if !domains.iter().any(|&d| host.eq_ignore_ascii_case(d.trim())) {
+            return Err(format!("Host '{}' is not in the allowed domains list", host));
+        }
+    }
+
+    Ok(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_valid_urls() {
+        assert!(validate_internal_url("http://localhost:8006").is_ok());
+        assert!(validate_internal_url("https://example.com").is_ok());
+        assert!(validate_internal_url("http://127.0.0.1:8006").is_ok());
+    }
+
+    #[test]
+    fn test_validate_invalid_format() {
+        assert!(validate_internal_url("not-a-url").is_err());
+    }
+
+    #[test]
+    fn test_validate_unsupported_scheme() {
+        assert!(validate_internal_url("ftp://localhost").is_err());
+        assert!(validate_internal_url("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_validate_forbidden_hosts() {
+        assert!(validate_internal_url("http://169.254.169.254").is_err());
+        assert!(validate_internal_url("http://metadata.google.internal").is_err());
+        assert!(validate_internal_url("http://METADATA").is_err());
+    }
+
+    #[test]
+    fn test_validate_link_local() {
+        assert!(validate_internal_url("http://169.254.1.1").is_err());
+    }
+
+    #[test]
+    fn test_validate_allowlist() {
+        std::env::set_var("XAVIER2_ALLOWED_DOMAINS", "local.host, internal.corp");
+
+        assert!(validate_internal_url("http://local.host").is_ok());
+        assert!(validate_internal_url("http://internal.corp").is_ok());
+        assert!(validate_internal_url("http://example.com").is_err());
+
+        std::env::remove_var("XAVIER2_ALLOWED_DOMAINS");
+    }
+}

--- a/src/tasks/session_sync_task.rs
+++ b/src/tasks/session_sync_task.rs
@@ -468,12 +468,21 @@ impl Default for SessionSyncTask {
             timeout_ms: read_env_or_legacy("XAVIER2_SYNC_TIMEOUT_MS", "SEVIER2_SYNC_TIMEOUT_MS")
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(DEFAULT_SYNC_TIMEOUT_MS),
-            health_port: Arc::new(
-                crate::adapters::outbound::http_health_adapter::HttpHealthAdapter::new(
-                    std::env::var("XAVIER2_URL")
-                        .unwrap_or_else(|_| "http://localhost:8006".to_string()),
-                ),
-            ),
+            health_port: Arc::new({
+                let url_str = std::env::var("XAVIER2_URL")
+                    .unwrap_or_else(|_| "http://localhost:8006".to_string());
+
+                // Validate internal URL to prevent SSRF
+                let final_url = match crate::security::url_validator::validate_internal_url(&url_str) {
+                    Ok(_) => url_str,
+                    Err(e) => {
+                        tracing::error!("XAVIER2_URL validation failed in SessionSyncTask: {}. Falling back to localhost.", e);
+                        "http://localhost:8006".to_string()
+                    }
+                };
+
+                crate::adapters::outbound::http_health_adapter::HttpHealthAdapter::new(final_url)
+            }),
             storage_port: None,
             last_check: Arc::new(RwLock::new(Instant::now())),
         }

--- a/src/verification/cycle.rs
+++ b/src/verification/cycle.rs
@@ -333,16 +333,21 @@ impl VerificationCycle {
 impl VerificationCycle {
     /// Create from XAVIER2_URL and XAVIER2_TOKEN env vars
     pub fn from_env() -> Result<Self, String> {
-        let url = std::env::var("XAVIER2_URL")
+        let url_str = std::env::var("XAVIER2_URL")
             .or_else(|_| std::env::var("XAVIER2_API_URL"))
             .map_err(|_| "XAVIER2_URL not set")?;
+
+        // Validate internal URL to prevent SSRF
+        let validated_url = crate::security::url_validator::validate_internal_url(&url_str)
+            .map_err(|e| format!("XAVIER2_URL validation failed: {}", e))?;
+
         let token = std::env::var("XAVIER2_TOKEN")
             .or_else(|_| std::env::var("XAVIER2_AUTH_TOKEN"))
             .map_err(|_| "XAVIER2_TOKEN not set")?;
 
         Ok(Self::new(
             Client::new(),
-            url.trim_end_matches('/'),
+            validated_url.as_str().trim_end_matches('/'),
             token,
         ))
     }


### PR DESCRIPTION
This PR addresses a medium-high severity SSRF risk where the `XAVIER2_URL` environment variable was used for outbound HTTP requests without validation. 

Key changes:
1. **New URL Validator**: Added `validate_internal_url` in `src/security/url_validator.rs` which checks for valid HTTP/HTTPS schemes, blocks known cloud metadata service IPs/hosts, and enforces an optional allowlist.
2. **Handler Protection**: Modified `verify_save_handler` to return an error if the configured `XAVIER2_URL` fails validation.
3. **Internal Task Protection**: Secured `SessionSyncTask` and `VerificationCycle` which also use this environment variable.
4. **Testing**: Added unit tests covering various SSRF payloads and allowlist scenarios.

Fixes #136

---
*PR created automatically by Jules for task [909666311402460816](https://jules.google.com/task/909666311402460816) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of internal URLs to prevent connections to metadata endpoints and link-local addresses, with enhanced error handling and logging.
  * Invalid URLs now return appropriate error responses with clear failure indicators.

* **New Features**
  * Added optional domain allowlist support to restrict internal connections to specified hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->