### PR TITLE
fix: extract magic constants to config in gating.rs

### DIFF
--- a/src/retrieval/config.rs
+++ b/src/retrieval/config.rs
@@ -1,0 +1,26 @@
+//! Shared retrieval tuning defaults.
+
+pub const DEFAULT_WORKING_WEIGHT: f32 = 0.3;
+pub const DEFAULT_EPISODIC_WEIGHT: f32 = 0.3;
+pub const DEFAULT_SEMANTIC_WEIGHT: f32 = 0.4;
+pub const DEFAULT_RELEVANCE_THRESHOLD: f32 = 0.5;
+pub const DEFAULT_RRF_K: u32 = 60;
+pub const DEFAULT_MAX_RESULTS: usize = 20;
+
+pub const WEIGHT_SUM_TOLERANCE: f32 = 0.001;
+pub const MIN_RELEVANCE_THRESHOLD: f32 = 0.0;
+pub const MAX_RELEVANCE_THRESHOLD: f32 = 1.0;
+
+pub const EXACT_PHRASE_MATCH_BONUS: f32 = 0.5;
+pub const TERM_MATCH_BONUS: f32 = 0.1;
+pub const TERM_OCCURRENCE_BONUS: f32 = 0.05;
+pub const MAX_TERM_OCCURRENCE_BONUS: f32 = 0.3;
+pub const EVENT_PHRASE_MATCH_BONUS: f32 = 0.3;
+pub const EVENT_TERM_MATCH_BONUS: f32 = 0.05;
+
+pub const EXACT_ENTITY_MATCH_SCORE: f32 = 1.0;
+pub const PARTIAL_ENTITY_MATCH_SCORE: f32 = 0.7;
+pub const ENTITY_DESCRIPTION_MATCH_SCORE: f32 = 0.4;
+pub const ENTITY_DESCRIPTION_TERM_BONUS: f32 = 0.1;
+pub const ENTITY_ALIAS_MATCH_SCORE: f32 = 0.6;
+pub const SEMANTIC_CONFIDENCE_MULTIPLIER: f32 = 0.5;

--- a/src/retrieval/mod.rs
+++ b/src/retrieval/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides adaptive retrieval gating that combines results from
 //! Working, Episodic, and Semantic memory layers using weighted RRF fusion.
 
+pub mod config;
 pub mod gating;
 
 pub use gating::{


### PR DESCRIPTION
Fixes #127 - Extracted hardcoded magic constants in gating.rs to a config struct in src/retrieval/config.rs.