### PR TITLE
fix: implement real estimate_index_lag in SessionSyncTask

### DIFF
--- a/src/tasks/session_sync_task.rs
+++ b/src/tasks/session_sync_task.rs
@@ -373,45 +373,32 @@ impl SessionSyncTask {
         }
     }
 
-    /// Estimate index lag by querying session memory records and comparing
-    /// the most recent record's updated_at timestamp with the current time.
-    /// Falls back to time-since-last-check if storage is unavailable.
+    /// Estimate index lag by querying indexed session records and comparing
+    /// the original event timestamp with the timestamp at which the record was indexed.
     async fn estimate_index_lag(&self) -> u64 {
-        use std::time::SystemTime;
-
-        // Try to query session records from storage
         if let Some(ref storage) = self.storage_port {
             let records = match storage.list("session", 1000).await {
                 Ok(recs) => recs,
                 Err(e) => {
                     tracing::warn!(error = %e, "Failed to list session records for lag estimation");
-                    return self.fallback_lag().await;
+                    return 0;
                 }
             };
 
-            let now = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_millis() as u64)
-                .unwrap_or(0);
-
-            if let Some(lag) = records
+            if let Some((event_ts, indexed_ts)) = records
                 .iter()
                 .filter(|r| r.namespace == MemoryNamespace::Session)
-                .map(|r| r.updated_at.timestamp_millis() as u64)
-                .max()
-                .map(|last_updated| now.saturating_sub(last_updated))
+                .filter_map(|record| {
+                    session_event_timestamp_ms(&record.content)
+                        .map(|ts| (ts, record.updated_at.timestamp_millis()))
+                })
+                .max_by_key(|(event_ts, _)| *event_ts)
             {
-                return lag.min(60_000); // cap at 60s
+                return indexed_ts.saturating_sub(event_ts).max(0) as u64;
             }
         }
 
-        self.fallback_lag().await
-    }
-
-    /// Fallback lag estimation using time since last successful check.
-    async fn fallback_lag(&self) -> u64 {
-        let last = *self.last_check.read().await;
-        last.elapsed().as_millis() as u64
+        0
     }
 
     /// Get save_ok_rate from stored metrics
@@ -515,4 +502,34 @@ fn read_env_or_legacy(primary: &str, legacy: &str) -> Option<String> {
     std::env::var(primary)
         .ok()
         .or_else(|| std::env::var(legacy).ok())
+}
+
+fn session_event_timestamp_ms(content: &str) -> Option<i64> {
+    let value: serde_json::Value = serde_json::from_str(content).ok()?;
+    timestamp_ms_from_json(&value)
+}
+
+fn timestamp_ms_from_json(value: &serde_json::Value) -> Option<i64> {
+    let object = value.as_object()?;
+
+    for key in ["timestamp", "event_timestamp", "created_at"] {
+        if let Some(timestamp) = object.get(key).and_then(parse_timestamp_ms) {
+            return Some(timestamp);
+        }
+    }
+
+    object
+        .get("metadata")
+        .and_then(timestamp_ms_from_json)
+}
+
+fn parse_timestamp_ms(value: &serde_json::Value) -> Option<i64> {
+    if let Some(milliseconds) = value.as_i64() {
+        return Some(milliseconds);
+    }
+
+    let timestamp = value.as_str()?;
+    chrono::DateTime::parse_from_rfc3339(timestamp)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
 }

--- a/tests/sync_check_handler_cached_result.rs
+++ b/tests/sync_check_handler_cached_result.rs
@@ -52,10 +52,17 @@ impl StoragePort for MockStoragePort {
 }
 
 fn make_session_record(seconds_ago: i64) -> MemoryRecord {
-    let updated_at = Utc::now() - chrono::Duration::seconds(seconds_ago);
+    let event_at = Utc::now() - chrono::Duration::seconds(seconds_ago);
+    let indexed_at = Utc::now();
     MemoryRecord {
         id: "session-1".to_string(),
-        content: "test".to_string(),
+        content: serde_json::json!({
+            "session_id": "session-1",
+            "event_type": "message",
+            "timestamp": event_at,
+            "content": "test",
+        })
+        .to_string(),
         kind: MemoryKind::Context,
         namespace: MemoryNamespace::Session,
         provenance: MemoryProvenance {
@@ -64,8 +71,8 @@ fn make_session_record(seconds_ago: i64) -> MemoryRecord {
             confidence: 1.0,
         },
         embedding: None,
-        created_at: updated_at,
-        updated_at,
+        created_at: event_at,
+        updated_at: indexed_at,
     }
 }
 


### PR DESCRIPTION
Fixes #79 - SessionSyncTask::estimate_index_lag() was returning a proxy value stub. Implemented real lag estimation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved session synchronization lag calculation to use event timestamps from session records instead of current time, providing more accurate lag estimation.

* **Tests**
  * Updated test fixtures to reflect new timestamp handling and session record structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->