### PR TITLE
Fix hardcoded RRF_K constants with environment variable support

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -61,7 +61,9 @@ pub async fn hybrid_search(
     let searcher = HybridSearcher {
         keyword_weight: request.keyword_weight,
         vector_weight: request.vector_weight,
-        rrf_k: request.rrf_k.unwrap_or(60),
+        rrf_k: request
+            .rrf_k
+            .unwrap_or_else(crate::search::hybrid::configured_rrf_k),
         hooks: crate::search::hooks::HookRegistry::new(),
     };
 

--- a/src/retrieval/config.rs
+++ b/src/retrieval/config.rs
@@ -5,6 +5,13 @@ pub const DEFAULT_EPISODIC_WEIGHT: f32 = 0.3;
 pub const DEFAULT_SEMANTIC_WEIGHT: f32 = 0.4;
 pub const DEFAULT_RELEVANCE_THRESHOLD: f32 = 0.5;
 pub const DEFAULT_RRF_K: u32 = 60;
+
+pub fn configured_rrf_k() -> u32 {
+    std::env::var("XAVIER2_RRF_K")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(DEFAULT_RRF_K)
+}
 pub const DEFAULT_MAX_RESULTS: usize = 20;
 pub const DEFAULT_SEARCH_LIMIT: usize = 10;
 pub const DEFAULT_KEYWORD_WEIGHT: f32 = 0.5;

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -19,7 +19,7 @@ pub enum SearchError {
     Hook(String),
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct HybridSearcher {
     pub keyword_weight: f32,
     pub vector_weight: f32,
@@ -27,14 +27,24 @@ pub struct HybridSearcher {
     pub hooks: HookRegistry,
 }
 
-impl HybridSearcher {
-    pub fn new() -> Self {
+impl Default for HybridSearcher {
+    fn default() -> Self {
         Self {
             keyword_weight: 0.5,
             vector_weight: 0.5,
-            rrf_k: 60,
+            rrf_k: configured_rrf_k(),
             hooks: HookRegistry::new(),
         }
+    }
+}
+
+pub fn configured_rrf_k() -> u32 {
+    crate::retrieval::config::configured_rrf_k()
+}
+
+impl HybridSearcher {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub async fn search(
@@ -218,6 +228,14 @@ mod tests {
             }
             Ok(())
         }
+    }
+
+    #[test]
+    fn test_configured_rrf_k_from_env() {
+        std::env::set_var("XAVIER2_RRF_K", "100");
+        assert_eq!(configured_rrf_k(), 100);
+        std::env::remove_var("XAVIER2_RRF_K");
+        assert_eq!(configured_rrf_k(), 60);
     }
 
     #[tokio::test]

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -525,7 +525,7 @@ fn default_relevance_threshold() -> f32 {
 }
 
 fn default_rrf_k() -> u32 {
-    60
+    crate::search::hybrid::configured_rrf_k()
 }
 
 /// Response for multi-layer memory retrieval


### PR DESCRIPTION
The task was to remove the remaining hardcoded `60` constants for the RRF_K parameter and replace them with environment variable support (`XAVIER2_RRF_K`).

Changes made:
- **`src/retrieval/config.rs`**: Added a centralized `configured_rrf_k()` function that reads `XAVIER2_RRF_K`, defaulting to `DEFAULT_RRF_K` (60).
- **`src/search/hybrid.rs`**: 
    - Updated `HybridSearcher` to use `configured_rrf_k()`.
    - Manually implemented the `Default` trait for `HybridSearcher` to ensure that weights and `rrf_k` are initialized correctly and consistently between `new()` and `Default::default()`.
    - Added a unit test `test_configured_rrf_k_from_env` to verify that the environment variable correctly overrides the default value.
- **`src/api/search.rs`**: Updated the `hybrid_search` handler to use the new configuration helper.
- **`src/server/http.rs`**: Fixed an additional hardcoded `60` in the `default_rrf_k()` helper function.

Verified the changes by running `cargo test --lib search::hybrid`, which passed successfully.

Fixes #115

---
*PR created automatically by Jules for task [12006771293765938754](https://jules.google.com/task/12006771293765938754) started by @iberi22*