### PR TITLE
Chronicle Redact Module - Automatic Privacy Filter

### DIFF
--- a/src/chronicle/mod.rs
+++ b/src/chronicle/mod.rs
@@ -1,0 +1,9 @@
+//! Chronicle Module
+//!
+//! Chronicle provides security and data integrity layers for Xavier2.
+//! It includes automated redaction of sensitive information.
+
+pub mod patterns;
+pub mod redact;
+
+pub use redact::{process_output, redact, verify};

--- a/src/chronicle/patterns.rs
+++ b/src/chronicle/patterns.rs
@@ -1,0 +1,34 @@
+//! Patterns for Chronicle Redaction Module
+//!
+//! This file contains the configurable patterns used to identify sensitive information
+//! that should be redacted before outputting.
+
+/// List of redaction rules (pattern, replacement)
+pub const REDACTION_PATTERNS: &[(&str, &str)] = &[
+    // Internal repository paths (must be before core names to avoid partial redaction)
+    (r"(?i)(?:/|[a-zA-Z]:\\)(?:[^/\\\s]+[/\\])*xavier2(?:[/\\][^/\\\s]+)*", "[workspace]"),
+
+    // Project scripts path
+    (r"(?i)E:\\scripts-python\\[^\s]*", "[project]"),
+
+    // User home path
+    (r"(?i)C:\\Users\\belal\\[^\s]*", "[user-home]"),
+
+    // Internal IP addresses
+    (r"\b(192\.168\.\d{1,3}\.\d{1,3}|10\.\d{1,3}\.\d{1,3}\.\d{1,3})\b", "[internal-host]"),
+
+    // Localhost services
+    (r"(?i)localhost:\d+", "[internal-service]"),
+
+    // Stakeholder names (must be before core names if they overlap, like "Cortex Team")
+    (r"(?i)\b(Cortex Team|Belal|Xavier)\b", "[team-member]"),
+
+    // Core system names
+    (r"(?i)\b(Xavier2|Cortex)\b", "[memory-core]"),
+
+    // Credentials and Secrets
+    (r"(?i)(api[_-]?key|token|password|secret|credential)[ \t]*[:=][ \t]*[a-zA-Z0-9_\-\.]{8,}", "[REDACTED]"),
+
+    // Security vulnerabilities
+    (r"(?i)\b(CVE-\d{4}-\d+|XAVIER-SEC-\d+)\b", "[vulnerability-patched]"),
+];

--- a/src/chronicle/redact.rs
+++ b/src/chronicle/redact.rs
@@ -1,0 +1,140 @@
+//! Chronicle Redact Module
+//!
+//! Automatic privacy filter for sensitive content. This is a critical security layer.
+//! It redacts sensitive patterns and performs a fail-fast validation.
+
+use crate::chronicle::patterns::REDACTION_PATTERNS;
+use regex::Regex;
+use std::sync::LazyLock;
+use anyhow::{anyhow, Result};
+
+/// Compiled redaction rules
+static RULES: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
+    REDACTION_PATTERNS
+        .iter()
+        .map(|(pattern, replacement)| {
+            (Regex::new(pattern).expect("Invalid regex pattern"), *replacement)
+        })
+        .collect()
+});
+
+/// Redacts sensitive information from the input string.
+pub fn redact(input: &str) -> String {
+    let mut output = input.to_string();
+    for (regex, replacement) in &*RULES {
+        output = regex.replace_all(&output, *replacement).to_string();
+    }
+    output
+}
+
+/// Scans the output for any remaining sensitive patterns.
+/// Returns an error if any unredacted sensitive content is found (fail-fast).
+pub fn verify(output: &str) -> Result<()> {
+    for (regex, _) in &*RULES {
+        if regex.is_match(output) {
+            return Err(anyhow!("Sensitive content detected in post-redaction output: pattern '{}'", regex.as_str()));
+        }
+    }
+    Ok(())
+}
+
+/// Redacts and then verifies the output.
+pub fn process_output(input: &str) -> Result<String> {
+    let redacted = redact(input);
+    verify(&redacted)?;
+    Ok(redacted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_redact_project_path() {
+        let input = "The script is at E:\\scripts-python\\test.py";
+        let output = redact(input);
+        assert_eq!(output, "The script is at [project]");
+    }
+
+    #[test]
+    fn test_redact_user_home() {
+        let input = "Check C:\\Users\\belal\\documents";
+        let output = redact(input);
+        assert_eq!(output, "Check [user-home]");
+    }
+
+    #[test]
+    fn test_redact_ips() {
+        let input = "Connect to 192.168.1.1 or 10.0.0.5";
+        let output = redact(input);
+        assert_eq!(output, "Connect to [internal-host] or [internal-host]");
+    }
+
+    #[test]
+    fn test_redact_localhost() {
+        let input = "Server at localhost:8080";
+        let output = redact(input);
+        assert_eq!(output, "Server at [internal-service]");
+    }
+
+    #[test]
+    fn test_redact_core_names() {
+        let input = "Xavier2 is powered by Cortex";
+        let output = redact(input);
+        assert_eq!(output, "[memory-core] is powered by [memory-core]");
+    }
+
+    #[test]
+    fn test_redact_team_members() {
+        let input = "Contact Belal or the Cortex Team";
+        let output = redact(input);
+        assert_eq!(output, "Contact [team-member] or the [team-member]");
+    }
+
+    #[test]
+    fn test_redact_credentials() {
+        let input = "api_key=sk-1234567890abcdef and token: abcdef1234567890";
+        let output = redact(input);
+        assert_eq!(output, "[REDACTED] and [REDACTED]");
+    }
+
+    #[test]
+    fn test_redact_vulnerabilities() {
+        let input = "Fix CVE-2023-12345 immediately";
+        let output = redact(input);
+        assert_eq!(output, "Fix [vulnerability-patched] immediately");
+    }
+
+    #[test]
+    fn test_redact_workspace() {
+        let input = "Repo path: /home/user/projects/xavier2/src";
+        let output = redact(input);
+        assert_eq!(output, "Repo path: [workspace]");
+
+        let input2 = "Windows path: C:\\Work\\xavier2\\README.md";
+        let output2 = redact(input2);
+        assert_eq!(output2, "Windows path: [workspace]");
+    }
+
+    #[test]
+    fn test_verify_success() {
+        let safe_text = "This is safe content.";
+        assert!(verify(safe_text).is_ok());
+    }
+
+    #[test]
+    fn test_verify_fail() {
+        let unsafe_text = "Sensitive 192.168.1.1 inside.";
+        assert!(verify(unsafe_text).is_err());
+    }
+
+    #[test]
+    fn test_process_output_workflow() {
+        let input = "Secret: api_key=1234567890, Server: localhost:3000";
+        let result = process_output(input);
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.contains("[REDACTED]"));
+        assert!(output.contains("[internal-service]"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod a2a;
 pub mod agents;
+pub mod chronicle;
 pub mod api;
 pub mod checkpoint;
 pub mod consistency;


### PR DESCRIPTION
Implemented the Chronicle module for automated privacy filtering. This includes:
- A configurable list of patterns for redaction (e.g., project paths, user homes, internal IPs, localhost services, core names, stakeholders, and credentials).
- A redaction engine that applies these patterns with correct precedence.
- A fail-fast validation mechanism that scans the final output to ensure no sensitive data remains.
- Integration with the main library and unit tests verifying both successful redactions and detection of unredacted content.

Fixes #186

---
*PR created automatically by Jules for task [13499002077653591903](https://jules.google.com/task/13499002077653591903) started by @iberi22*