### PR TITLE
Implement Chronicle Harvest Module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -194,7 +194,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1208,7 +1208,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2328,7 +2328,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2747,7 +2747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3378,6 +3378,21 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "gl_generator"
@@ -4127,7 +4142,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4300,6 +4315,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4355,6 +4384,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4679,7 +4734,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -4785,7 +4840,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5254,6 +5309,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -6268,7 +6329,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6723,7 +6784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7056,7 +7117,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8476,7 +8537,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9165,6 +9226,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "generic-array",
+ "git2",
  "gllm",
  "hex",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ enterprise = []
 [dependencies]
 code-graph = { path = "./code-graph" }
 anyhow = "1.0.102"
+git2 = "0.19"
 async-trait = "0.1"
 reqwest = { version = "0.12", features = ["json"] }
 gllm = { version = "0.10.6", default-features = false, features = ["cpu"], optional = true }

--- a/code-graph/src/db/mod.rs
+++ b/code-graph/src/db/mod.rs
@@ -314,6 +314,41 @@ impl CodeGraphDB {
         })
     }
 
+    /// Find symbols in a specific file
+    pub fn find_by_file(&self, file_path: &str) -> Result<Vec<Symbol>> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut stmt = conn
+            .prepare(
+                r#"SELECT id, name, kind, lang, file_path, start_line, end_line, start_col, end_col, signature, parent
+                   FROM symbols
+                   WHERE file_path = ?1"#,
+            )
+            .map_err(|e| GraphError::Database(e.to_string()))?;
+
+        let symbols = stmt
+            .query_map(params![file_path], |row| {
+                Ok(Symbol {
+                    id: Some(row.get(0)?),
+                    name: row.get(1)?,
+                    kind: parse_symbol_kind(&row.get::<_, String>(2)?),
+                    lang: parse_language(&row.get::<_, String>(3)?),
+                    file_path: row.get(4)?,
+                    start_line: row.get(5)?,
+                    end_line: row.get(6)?,
+                    start_col: row.get(7)?,
+                    end_col: row.get(8)?,
+                    signature: row.get(9)?,
+                    parent: row.get(10)?,
+                })
+            })
+            .map_err(|e| GraphError::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(symbols)
+    }
+
     /// Find symbols by kind
     pub fn find_by_kind(&self, kind: SymbolKind, limit: usize) -> Result<Vec<Symbol>> {
         let conn = self.conn.lock().unwrap();

--- a/src/chronicle/harvest.rs
+++ b/src/chronicle/harvest.rs
@@ -1,0 +1,293 @@
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use git2::{Repository, Sort};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::memory::qmd_memory::QmdMemory;
+use code_graph::db::CodeGraphDB;
+use code_graph::types::Symbol;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HarvestOutput {
+    pub date: String,
+    pub commits: Vec<CommitInfo>,
+    pub decisions: Vec<MemoryEntry>,
+    pub bugs: Vec<MemoryEntry>,
+    pub sessions: Vec<SessionInfo>,
+    pub code_changes: Vec<CodeChangeInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CommitInfo {
+    pub hash: String,
+    pub message: String,
+    pub files: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MemoryEntry {
+    pub path: String,
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SessionInfo {
+    pub id: String,
+    pub duration_ms: u64,
+    pub tokens: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CodeChangeInfo {
+    pub file: String,
+    pub symbols: Vec<String>,
+}
+
+pub struct Harvester {
+    workspace_path: PathBuf,
+    memory: Arc<QmdMemory>,
+    code_db: Arc<CodeGraphDB>,
+}
+
+impl Harvester {
+    pub fn new(workspace_path: PathBuf, memory: Arc<QmdMemory>, code_db: Arc<CodeGraphDB>) -> Self {
+        Self {
+            workspace_path,
+            memory,
+            code_db,
+        }
+    }
+
+    pub async fn run(&self, since: DateTime<Utc>) -> Result<PathBuf> {
+        let date = Utc::now().format("%Y-%m-%d").to_string();
+
+        let commits = self.harvest_commits(since)?;
+        let decisions = self.harvest_memories("decisions/*").await?;
+        let bugs = self.harvest_memories("bugs/*").await?;
+        let sessions = self.harvest_sessions().await?;
+
+        let modified_files: HashSet<String> = commits.iter()
+            .flat_map(|c| c.files.clone())
+            .collect();
+
+        let code_changes = self.harvest_code_changes(modified_files)?;
+
+        let output = HarvestOutput {
+            date: date.clone(),
+            commits,
+            decisions,
+            bugs,
+            sessions,
+            code_changes,
+        };
+
+        let chronicle_dir = self.workspace_path.join(".chronicle");
+        if !chronicle_dir.exists() {
+            std::fs::create_dir_all(&chronicle_dir)?;
+        }
+
+        let file_path = chronicle_dir.join(format!("harvest-{}.json", date));
+        let json = serde_json::to_string_pretty(&output)?;
+        std::fs::write(&file_path, json)?;
+
+        Ok(file_path)
+    }
+
+    fn harvest_commits(&self, since: DateTime<Utc>) -> Result<Vec<CommitInfo>> {
+        let repo = Repository::open(&self.workspace_path)
+            .map_err(|e| anyhow!("Failed to open repo at {:?}: {}", self.workspace_path, e))?;
+
+        let mut revwalk = repo.revwalk()?;
+        revwalk.set_sorting(Sort::TIME | Sort::REVERSE)?;
+        revwalk.push_head()?;
+
+        let mut commit_infos = Vec::new();
+
+        for id in revwalk {
+            let id = id?;
+            let commit = repo.find_commit(id)?;
+            let commit_time = DateTime::<Utc>::from_timestamp(commit.time().seconds(), 0)
+                .ok_or_else(|| anyhow!("Invalid commit timestamp"))?;
+
+            if commit_time >= since {
+                let mut files = Vec::new();
+
+                // Get diff to find modified files
+                if let Ok(parent) = commit.parent(0) {
+                    let diff = repo.diff_tree_to_tree(
+                        Some(&parent.tree()?),
+                        Some(&commit.tree()?),
+                        None
+                    )?;
+                    diff.foreach(&mut |delta, _| {
+                        if let Some(new_file) = delta.new_file().path() {
+                            if let Some(path_str) = new_file.to_str() {
+                                files.push(path_str.to_string());
+                            }
+                        }
+                        true
+                    }, None, None, None)?;
+                } else {
+                    // Initial commit
+                    let tree = commit.tree()?;
+                    tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
+                        if let Some(name) = entry.name() {
+                            files.push(format!("{}{}", root, name));
+                        }
+                        git2::TreeWalkResult::Ok
+                    })?;
+                }
+
+                commit_infos.push(CommitInfo {
+                    hash: id.to_string(),
+                    message: commit.message().unwrap_or_default().trim().to_string(),
+                    files,
+                });
+            }
+        }
+
+        Ok(commit_infos)
+    }
+
+    async fn harvest_memories(&self, pattern: &str) -> Result<Vec<MemoryEntry>> {
+        let docs = self.memory.all_documents().await;
+        let mut entries = Vec::new();
+
+        // Simple glob-to-regex or prefix match for patterns like "decisions/*"
+        let prefix = pattern.trim_end_matches('*');
+
+        for doc in docs {
+            if doc.path.starts_with(prefix) {
+                entries.push(MemoryEntry {
+                    path: doc.path.clone(),
+                    content: doc.content.clone(),
+                    status: doc.metadata.get("status").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                });
+            }
+        }
+
+        Ok(entries)
+    }
+
+    async fn harvest_sessions(&self) -> Result<Vec<SessionInfo>> {
+        let docs = self.memory.all_documents().await;
+        let mut sessions = Vec::new();
+
+        for doc in docs {
+            if doc.path.starts_with("sessions/") {
+                // Heuristic: only pick summaries or direct session docs, avoiding every single turn
+                if doc.path.contains("/summary") || !doc.path.contains("/turns/") {
+                    let duration_ms = doc.metadata.get("duration_ms").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let tokens = doc.metadata.get("tokens").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+
+                    sessions.push(SessionInfo {
+                        id: doc.path.clone(),
+                        duration_ms,
+                        tokens,
+                    });
+                }
+            }
+        }
+
+        Ok(sessions)
+    }
+
+    fn harvest_code_changes(&self, modified_files: HashSet<String>) -> Result<Vec<CodeChangeInfo>> {
+        let mut code_changes = Vec::new();
+
+        for file in modified_files {
+            // Find symbols in this file using CodeGraphDB
+            let symbols = self.find_symbols_in_file(&file)?;
+            if !symbols.is_empty() {
+                code_changes.push(CodeChangeInfo {
+                    file,
+                    symbols: symbols.into_iter().map(|s| s.name).collect(),
+                });
+            }
+        }
+
+        Ok(code_changes)
+    }
+
+    fn find_symbols_in_file(&self, file_path: &str) -> Result<Vec<Symbol>> {
+        self.code_db.find_by_file(file_path).map_err(|e| anyhow!("DB error: {}", e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::qmd_memory::MemoryDocument;
+    use tokio::sync::RwLock as AsyncRwLock;
+
+    #[tokio::test]
+    async fn test_harvest_output_serialization() {
+        let output = HarvestOutput {
+            date: "2026-05-07".to_string(),
+            commits: vec![CommitInfo {
+                hash: "abc".to_string(),
+                message: "feat: something".to_string(),
+                files: vec!["src/lib.rs".to_string()],
+            }],
+            decisions: vec![MemoryEntry {
+                path: "decisions/001-arch.md".to_string(),
+                content: "Use Rust".to_string(),
+                status: Some("accepted".to_string()),
+            }],
+            bugs: vec![],
+            sessions: vec![],
+            code_changes: vec![],
+        };
+
+        let json = serde_json::to_string(&output).unwrap();
+        assert!(json.contains("2026-05-07"));
+        assert!(json.contains("decisions/001-arch.md"));
+    }
+
+    #[tokio::test]
+    async fn test_harvest_memories() {
+        let memory = Arc::new(QmdMemory::new(Arc::new(AsyncRwLock::new(vec![
+            MemoryDocument {
+                id: Some("1".into()),
+                path: "decisions/use-rust.md".into(),
+                content: "Content".into(),
+                metadata: serde_json::json!({"status": "accepted"}),
+                content_vector: None,
+                embedding: vec![],
+            },
+            MemoryDocument {
+                id: Some("2".into()),
+                path: "bugs/fix-ui.md".into(),
+                content: "Content".into(),
+                metadata: serde_json::json!({"status": "resolved"}),
+                content_vector: None,
+                embedding: vec![],
+            },
+            MemoryDocument {
+                id: Some("3".into()),
+                path: "other/note.md".into(),
+                content: "Content".into(),
+                metadata: serde_json::json!({}),
+                content_vector: None,
+                embedding: vec![],
+            },
+        ]))));
+
+        let code_db = Arc::new(CodeGraphDB::in_memory().unwrap());
+        let harvester = Harvester::new(PathBuf::from("."), memory, code_db);
+
+        let decisions = harvester.harvest_memories("decisions/*").await.unwrap();
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].path, "decisions/use-rust.md");
+        assert_eq!(decisions[0].status, Some("accepted".to_string()));
+
+        let bugs = harvester.harvest_memories("bugs/*").await.unwrap();
+        assert_eq!(bugs.len(), 1);
+        assert_eq!(bugs[0].path, "bugs/fix-ui.md");
+    }
+}

--- a/src/chronicle/mod.rs
+++ b/src/chronicle/mod.rs
@@ -1,0 +1,1 @@
+pub mod harvest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod a2a;
 pub mod agents;
 pub mod api;
 pub mod checkpoint;
+pub mod chronicle;
 pub mod consistency;
 pub mod consolidation;
 pub mod context;

--- a/tests/chronicle_harvest_test.rs
+++ b/tests/chronicle_harvest_test.rs
@@ -1,0 +1,74 @@
+use chrono::{Duration, Utc};
+use std::fs;
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::sync::RwLock as AsyncRwLock;
+
+use xavier2::chronicle::harvest::Harvester;
+use xavier2::memory::qmd_memory::{MemoryDocument, QmdMemory};
+use code_graph::db::CodeGraphDB;
+use code_graph::types::{Language, Symbol, SymbolKind};
+
+#[tokio::test]
+async fn test_full_harvest_workflow() {
+    let temp_dir = TempDir::new().unwrap();
+    let workspace_path = temp_dir.path();
+
+    // 1. Initialize a git repo
+    let repo = git2::Repository::init(workspace_path).unwrap();
+    let mut index = repo.index().unwrap();
+
+    let file_path = workspace_path.join("src/main.rs");
+    fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+    fs::write(&file_path, "fn main() {}").unwrap();
+
+    index.add_path(std::path::Path::new("src/main.rs")).unwrap();
+    let id = index.write_tree().unwrap();
+    let tree = repo.find_tree(id).unwrap();
+    let sig = repo.signature().unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial commit", &tree, &[]).unwrap();
+
+    // 2. Setup QmdMemory
+    let memory = Arc::new(QmdMemory::new(Arc::new(AsyncRwLock::new(vec![
+        MemoryDocument {
+            id: Some("d1".into()),
+            path: "decisions/arch.md".into(),
+            content: "Use SQLite".into(),
+            metadata: serde_json::json!({"status": "accepted"}),
+            content_vector: None,
+            embedding: vec![],
+        },
+    ]))));
+
+    // 3. Setup CodeGraphDB
+    let code_db = Arc::new(CodeGraphDB::in_memory().unwrap());
+    code_db.insert_symbol(&Symbol {
+        id: None,
+        name: "main".into(),
+        kind: SymbolKind::Function,
+        lang: Language::Rust,
+        file_path: "src/main.rs".into(),
+        start_line: 1,
+        end_line: 1,
+        start_col: 0,
+        end_col: 10,
+        signature: Some("fn main()".into()),
+        parent: None,
+    }).unwrap();
+
+    // 4. Run Harvester
+    let harvester = Harvester::new(workspace_path.to_path_buf(), memory, code_db);
+    let since = Utc::now() - Duration::days(1);
+
+    let output_path = harvester.run(since).await.unwrap();
+
+    // 5. Verify Output
+    assert!(output_path.exists());
+    let content = fs::read_to_string(output_path).unwrap();
+    let output: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+    assert_eq!(output["decisions"][0]["path"], "decisions/arch.md");
+    assert_eq!(output["commits"][0]["message"], "initial commit");
+    assert_eq!(output["code_changes"][0]["file"], "src/main.rs");
+    assert_eq!(output["code_changes"][0]["symbols"][0], "main");
+}


### PR DESCRIPTION
This PR implements the Chronicle Harvest module, which collects local operation data (git commits, memories, sessions, and code changes) into structured JSON reports. It includes git2 integration, QmdMemory queries, and CodeGraph symbol lookup.

Fixes #185

---
*PR created automatically by Jules for task [8026075546094103305](https://jules.google.com/task/8026075546094103305) started by @iberi22*