### PR TITLE
Add chronicle CLI subcommand

### DIFF
--- a/src/chronicle/cli.rs
+++ b/src/chronicle/cli.rs
@@ -1,0 +1,145 @@
+use clap::Subcommand;
+use anyhow::Result;
+
+#[derive(Subcommand, Debug, Clone, PartialEq)]
+pub enum ChronicleCommand {
+    /// Recolecta datos locales: commits, memoria, sesiones, cambios de código
+    Harvest {
+        /// Recolectar desde esta fecha
+        #[arg(long)]
+        since: Option<String>,
+        /// Ruta al workspace
+        #[arg(long)]
+        workspace: Option<String>,
+    },
+    /// Toma el harvest más reciente, aplica redact, genera el post vía LLM
+    Generate {
+        /// Generar desde esta fecha
+        #[arg(long)]
+        since: Option<String>,
+        /// Archivo de salida
+        #[arg(short, long)]
+        output: Option<String>,
+    },
+    /// Muestra el post generado con placeholders visibles
+    Preview {
+        /// Archivo a previsualizar
+        #[arg(long)]
+        file: Option<String>,
+    },
+    /// Exporta el post a markdown en la ruta especificada
+    Publish {
+        /// Ruta de destino del archivo markdown
+        #[arg(long)]
+        to: Option<String>,
+    },
+}
+
+pub async fn handle_chronicle_command(cmd: ChronicleCommand) -> Result<()> {
+    match cmd {
+        ChronicleCommand::Harvest { since, workspace } => {
+            println!("Chronicle: Harvesting data...");
+            if let Some(s) = since { println!("  Since: {}", s); }
+            if let Some(w) = workspace { println!("  Workspace: {}", w); }
+            // TODO: Implementation
+        }
+        ChronicleCommand::Generate { since, output } => {
+            println!("Chronicle: Generating post...");
+            if let Some(s) = since { println!("  Since: {}", s); }
+            if let Some(o) = output { println!("  Output: {}", o); }
+            // TODO: Implementation
+        }
+        ChronicleCommand::Preview { file } => {
+            println!("Chronicle: Previewing post...");
+            if let Some(f) = file { println!("  File: {}", f); }
+            // TODO: Implementation
+        }
+        ChronicleCommand::Publish { to } => {
+            println!("Chronicle: Publishing post...");
+            if let Some(t) = to { println!("  To: {}", t); }
+            // TODO: Implementation
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use crate::cli::{Cli, Command};
+
+    #[test]
+    fn test_chronicle_harvest_parsing() {
+        let args = vec!["xavier2", "chronicle", "harvest", "--since", "2026-05-01", "--workspace", "/path/to/ws"];
+        let cli = Cli::parse_from(args);
+
+        match cli.cmd.unwrap() {
+            Command::Chronicle { cmd } => {
+                match cmd {
+                    ChronicleCommand::Harvest { since, workspace } => {
+                        assert_eq!(since, Some("2026-05-01".to_string()));
+                        assert_eq!(workspace, Some("/path/to/ws".to_string()));
+                    },
+                    _ => panic!("Expected Harvest command"),
+                }
+            },
+            _ => panic!("Expected Chronicle command"),
+        }
+    }
+
+    #[test]
+    fn test_chronicle_generate_parsing() {
+        let args = vec!["xavier2", "chronicle", "generate", "--since", "2026-05-01", "--output", "post.md"];
+        let cli = Cli::parse_from(args);
+
+        match cli.cmd.unwrap() {
+            Command::Chronicle { cmd } => {
+                match cmd {
+                    ChronicleCommand::Generate { since, output } => {
+                        assert_eq!(since, Some("2026-05-01".to_string()));
+                        assert_eq!(output, Some("post.md".to_string()));
+                    },
+                    _ => panic!("Expected Generate command"),
+                }
+            },
+            _ => panic!("Expected Chronicle command"),
+        }
+    }
+
+    #[test]
+    fn test_chronicle_preview_parsing() {
+        let args = vec!["xavier2", "chronicle", "preview", "--file", "harvest.json"];
+        let cli = Cli::parse_from(args);
+
+        match cli.cmd.unwrap() {
+            Command::Chronicle { cmd } => {
+                match cmd {
+                    ChronicleCommand::Preview { file } => {
+                        assert_eq!(file, Some("harvest.json".to_string()));
+                    },
+                    _ => panic!("Expected Preview command"),
+                }
+            },
+            _ => panic!("Expected Chronicle command"),
+        }
+    }
+
+    #[test]
+    fn test_chronicle_publish_parsing() {
+        let args = vec!["xavier2", "chronicle", "publish", "--to", "./daily.md"];
+        let cli = Cli::parse_from(args);
+
+        match cli.cmd.unwrap() {
+            Command::Chronicle { cmd } => {
+                match cmd {
+                    ChronicleCommand::Publish { to } => {
+                        assert_eq!(to, Some("./daily.md".to_string()));
+                    },
+                    _ => panic!("Expected Publish command"),
+                }
+            },
+            _ => panic!("Expected Chronicle command"),
+        }
+    }
+}

--- a/src/chronicle/mod.rs
+++ b/src/chronicle/mod.rs
@@ -1,0 +1,1 @@
+pub mod cli;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,6 +95,11 @@ pub enum Command {
         #[arg(short = 'x', long)]
         context: Vec<String>,
     },
+    /// Subcomando para gestionar Chronicle
+    Chronicle {
+        #[command(subcommand)]
+        cmd: crate::chronicle::cli::ChronicleCommand,
+    },
 }
 
 /// Xavier2 - Fast Vector Memory for AI Agents
@@ -142,6 +147,7 @@ impl Cli {
                 skills,
                 context,
             } => spawn_agents(*count, provider.clone(), model.clone(), skills, context).await,
+            Command::Chronicle { cmd } => crate::chronicle::cli::handle_chronicle_command(cmd.clone()).await,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 // Public open-core release
 
 mod cli;
+mod chronicle;
 mod settings;
 extern crate xavier2 as xavier2_lib;
 


### PR DESCRIPTION
I have added the `chronicle` subcommand to the Xavier2 CLI. This includes the definition of four subcommands: `harvest`, `generate`, `preview`, and `publish`, each with their respective arguments as specified. The module is well-structured in `src/chronicle/` and integrated into the main CLI parser in `src/cli.rs`. Unit tests have been added to ensure that the CLI arguments are parsed correctly.

Fixes #188

---
*PR created automatically by Jules for task [13960046076066940805](https://jules.google.com/task/13960046076066940805) started by @iberi22*