### PR TITLE
Gestalt Rust → Xavier2: Unified Memory Backend (Phase 1)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,7 @@ use xavier2::session::event_mapper::PanelThreadEntry;
 use xavier2::session::types::SessionEvent;
 use xavier2::tasks::session_sync_task::SessionSyncTask;
 use xavier2::time::TimeMetricsStore;
+use xavier2::workspace::{WorkspaceConfig, WorkspaceContext, WorkspaceState};
 
 use crate::settings::Xavier2Settings;
 
@@ -48,6 +49,7 @@ pub struct CliState {
     pub store: Arc<dyn MemoryStore>,
     pub workspace_id: String,
     pub workspace_dir: PathBuf,
+    pub workspace_context: WorkspaceContext,
     pub code_db: Arc<code_graph::db::CodeGraphDB>,
     pub code_indexer: Arc<code_graph::indexer::Indexer>,
     pub code_query: Arc<code_graph::query::QueryEngine>,
@@ -228,11 +230,24 @@ async fn start_http_server(port: u16) -> Result<()> {
     ).unwrap_or_else(|_| PathBuf::from("."));
     info!("Workspace root for path security: {}", workspace_dir.display());
 
+    let workspace_state = WorkspaceState::new(
+        WorkspaceConfig::from_env(),
+        xavier2::agents::RuntimeConfig::default(),
+        workspace_dir.clone(),
+    )
+    .await?;
+
+    let workspace_context = WorkspaceContext {
+        workspace_id: workspace_id.clone(),
+        workspace: Arc::new(workspace_state),
+    };
+
     let state = CliState {
         memory: memory_port,
         store,
         workspace_id,
         workspace_dir,
+        workspace_context,
         code_db,
         code_indexer,
         code_query,
@@ -276,6 +291,12 @@ async fn start_http_server(port: u16) -> Result<()> {
         .route("/xavier2/sync/check", post(sync_check_handler))
         .route("/xavier2/sync/check", get(sync_check_handler))
         .route("/xavier2/verify/save", post(verify_save_handler))
+        .route("/v1/timeline/events", get(xavier2::server::v1_api::v1_timeline_events))
+        .route("/v1/memories", post(xavier2::server::v1_api::v1_memories_add).get(xavier2::server::v1_api::v1_memories_list))
+        .route("/v1/memories/{id}", get(xavier2::server::v1_api::v1_memories_get).put(xavier2::server::v1_api::v1_memories_update).delete(xavier2::server::v1_api::v1_memories_delete))
+        .route("/v1/memories/search", post(xavier2::server::v1_api::v1_memories_search))
+        .route("/v1/memories/recent", get(xavier2::server::v1_api::v1_memories_recent))
+        .route("/v1/memories/context", post(xavier2::server::v1_api::v1_memories_context))
         .layer(middleware::from_fn(auth_middleware));
 
     // Add enterprise plugin routes if feature is enabled
@@ -295,6 +316,7 @@ async fn start_http_server(port: u16) -> Result<()> {
         .route("/panel", get(panel_index))
         .route("/panel/assets/{*path}", get(panel_asset))
         .merge(protected_routes)
+        .layer(axum::Extension(state.workspace_context.clone()))
         .with_state(state);
 
     let listener = TcpListener::bind(&bind_addr).await?;

--- a/src/memory/schema.rs
+++ b/src/memory/schema.rs
@@ -149,6 +149,7 @@ pub struct MemoryProvenance {
     pub source_type: Option<String>,
     pub repo_url: Option<String>,
     pub file_path: Option<String>,
+    pub chunk_id: Option<String>,
     pub symbol: Option<String>,
     pub url: Option<String>,
     pub message_id: Option<String>,
@@ -514,6 +515,10 @@ fn overlay_provenance(provenance: &mut MemoryProvenance, metadata: &Value, path:
         .or_else(|| string_value(metadata, "file_path"))
         .or_else(|| string_value(metadata, "source_path"))
         .or_else(|| Some(path.to_string()));
+    provenance.chunk_id = provenance
+        .chunk_id
+        .take()
+        .or_else(|| string_value(metadata, "chunk_id"));
     provenance.symbol = provenance
         .symbol
         .take()

--- a/src/server/v1_api.rs
+++ b/src/server/v1_api.rs
@@ -2,6 +2,7 @@
 
 use axum::{
     extract::{Path, Query},
+    http::StatusCode,
     response::IntoResponse,
     Extension, Json,
 };
@@ -35,6 +36,7 @@ pub struct V1AddMemoryRequest {
     pub evidence_kind: Option<EvidenceKind>,
     pub namespace: Option<MemoryNamespace>,
     pub provenance: Option<MemoryProvenance>,
+    pub importance: Option<f32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -71,10 +73,30 @@ pub struct V1SearchRequest {
     pub filters: Option<MemoryQueryFilters>,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V1ContextRequest {
+    pub query: String,
+    pub limit: Option<usize>,
+    pub filters: Option<MemoryQueryFilters>,
+    pub max_chars: Option<usize>,
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct V1MemorySearchResponse {
     pub status: String,
     pub results: Vec<V1MemoryResponse>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V1TimelineParams {
+    pub since: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V1RecentParams {
+    pub agent_id: Option<String>,
+    pub user_id: Option<String>,
+    pub limit: Option<usize>,
 }
 
 fn is_primary_memory(metadata: &serde_json::Value) -> bool {
@@ -107,6 +129,21 @@ pub async fn v1_memories_add(
         .clone()
         .unwrap_or_else(|| "default".to_string());
     let mut meta = payload.metadata.unwrap_or(serde_json::json!({}));
+    if let Some(importance) = payload.importance {
+        let priority = if importance >= 0.9 {
+            "critical"
+        } else if importance >= 0.7 {
+            "high"
+        } else if importance >= 0.4 {
+            "medium"
+        } else if importance >= 0.1 {
+            "low"
+        } else {
+            "ephemeral"
+        };
+        meta["memory_priority"] = serde_json::json!(priority);
+        meta["importance"] = serde_json::json!(importance);
+    }
     let mut namespace = payload.namespace;
     if let Some(uid) = payload.user_id {
         meta["user_id"] = serde_json::json!(uid);
@@ -171,6 +208,140 @@ pub async fn v1_memories_add(
             "message": e.to_string(),
         })),
     }
+}
+
+pub async fn v1_memories_recent(
+    Extension(workspace): Extension<WorkspaceContext>,
+    Query(params): Query<V1RecentParams>,
+) -> impl IntoResponse {
+    let limit = params.limit.unwrap_or(10);
+    let mut all_docs = workspace.workspace.memory.all_documents().await;
+
+    // Filter by agent_id or user_id
+    if let Some(agent_id) = params.agent_id {
+        all_docs.retain(|doc| {
+            doc.metadata
+                .get("agent_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| id == agent_id)
+                || doc
+                    .metadata
+                    .get("namespace")
+                    .and_then(|ns| ns.get("agent_id"))
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|id| id == agent_id)
+        });
+    }
+
+    if let Some(user_id) = params.user_id {
+        all_docs.retain(|doc| {
+            doc.path == user_id
+                || doc
+                    .metadata
+                    .get("user_id")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|id| id == user_id)
+                || doc
+                    .metadata
+                    .get("namespace")
+                    .and_then(|ns| ns.get("user_id"))
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|id| id == user_id)
+        });
+    }
+
+    // Sort by updated_at descending
+    all_docs.sort_by(|a, b| {
+        let a_time = a
+            .metadata
+            .get("updated_at")
+            .and_then(|v| v.as_str())
+            .or_else(|| a.metadata.get("created_at").and_then(|v| v.as_str()))
+            .unwrap_or("");
+        let b_time = b
+            .metadata
+            .get("updated_at")
+            .and_then(|v| v.as_str())
+            .or_else(|| b.metadata.get("created_at").and_then(|v| v.as_str()))
+            .unwrap_or("");
+        b_time.cmp(a_time)
+    });
+
+    let memories: Vec<_> = all_docs
+        .into_iter()
+        .take(limit)
+        .map(|doc| V1MemoryResponse {
+            id: doc.id.unwrap_or_default(),
+            memory: doc.content,
+            user_id: Some(doc.path),
+            metadata: doc.metadata,
+        })
+        .collect();
+
+    Json(serde_json::json!({
+        "status": "ok",
+        "memories": memories,
+    }))
+}
+
+pub async fn v1_timeline_events(
+    Extension(workspace): Extension<WorkspaceContext>,
+    Query(params): Query<V1TimelineParams>,
+) -> impl IntoResponse {
+    let since = params.since.unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
+    match workspace.workspace.durable_store().list_timeline_events(&workspace.workspace_id, &since).await {
+        Ok(events) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "status": "ok",
+                "events": events,
+            })),
+        ).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "status": "error",
+                "message": e.to_string(),
+            })),
+        ).into_response(),
+    }
+}
+
+pub async fn v1_memories_context(
+    Extension(workspace): Extension<WorkspaceContext>,
+    Json(payload): Json<V1ContextRequest>,
+) -> impl IntoResponse {
+    let limit = payload.limit.unwrap_or(10);
+    let max_chars = payload.max_chars.unwrap_or(4000);
+
+    let results = query_with_embedding_filtered(
+        &workspace.workspace.memory,
+        &payload.query,
+        limit,
+        payload.filters.as_ref(),
+    )
+    .await
+    .unwrap_or_default();
+
+    let mut context_parts = Vec::new();
+    let mut current_chars = 0;
+
+    for doc in results {
+        let part = format!("--- Memory ({}) ---\n{}\n", doc.path, doc.content);
+        if current_chars + part.len() > max_chars && !context_parts.is_empty() {
+            break;
+        }
+        current_chars += part.len();
+        context_parts.push(part);
+    }
+
+    let context_string = context_parts.join("\n");
+
+    Json(serde_json::json!({
+        "status": "ok",
+        "context": context_string,
+        "count": context_parts.len(),
+    }))
 }
 
 pub async fn v1_memories_search(
@@ -448,6 +619,8 @@ mod tests {
     fn test_router(state: AppState, workspace: WorkspaceContext) -> Router {
         Router::new()
             .route("/v1/memories", post(v1_memories_add).get(v1_memories_list))
+            .route("/v1/memories/recent", get(v1_memories_recent))
+            .route("/v1/memories/context", post(v1_memories_context))
             .route(
                 "/v1/memories/{id}",
                 get(v1_memories_get)


### PR DESCRIPTION
Enhanced Xavier2's V1 REST API to provide the necessary surface for Gestalt Rust's MemoryService requirements. Key additions include timeline event polling, recent memory retrieval, and formatted context building for LLMs. Updated the core memory schema to support Gestalt's provenance and importance fields.

Fixes #149

---
*PR created automatically by Jules for task [17253446379095417823](https://jules.google.com/task/17253446379095417823) started by @iberi22*