### PR TITLE
Floating egui Configuration Window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,37 +3,13 @@
 version = 3
 
 [[package]]
-name = "ab_glyph"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
-dependencies = [
- "ab_glyph_rasterizer",
- "owned_ttf_parser",
-]
-
-[[package]]
-name = "ab_glyph_rasterizer"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
-
-[[package]]
-name = "accesskit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
-dependencies = [
- "enumn",
- "serde",
-]
-
-[[package]]
 name = "accesskit"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
 dependencies = [
+ "enumn",
+ "serde",
  "uuid",
 ]
 
@@ -2489,22 +2465,13 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "ecolor"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddb8ac7643d1dba1bb02110e804406dd459a838efcb14011ced10556711a8e"
-dependencies = [
- "emath 0.33.3",
- "serde",
-]
-
-[[package]]
-name = "ecolor"
 version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55f6cc0cb3b84a21232c468db972ebcddd34decbf1ff02cdebffd807c13bbd81"
 dependencies = [
  "bytemuck",
- "emath 0.34.2",
+ "emath",
+ "serde",
 ]
 
 [[package]]
@@ -2516,7 +2483,7 @@ dependencies = [
  "ahash",
  "bytemuck",
  "document-features",
- "egui 0.34.2",
+ "egui",
  "egui-winit",
  "egui_glow",
  "glow 0.17.0",
@@ -2543,37 +2510,19 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9b567d356674e9a5121ed3fedfb0a7c31e059fe71f6972b691bcd0bfc284e3"
-dependencies = [
- "accesskit 0.21.1",
- "ahash",
- "bitflags 2.11.1",
- "emath 0.33.3",
- "epaint 0.33.3",
- "log",
- "nohash-hasher",
- "profiling",
- "serde",
- "smallvec",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "egui"
 version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbe28ac1a9c0761319aafb9ad37737720cc49d99c13a4a6b990768fa01ffe67"
 dependencies = [
- "accesskit 0.24.0",
+ "accesskit",
  "ahash",
  "bitflags 2.11.1",
- "emath 0.34.2",
- "epaint 0.34.2",
+ "emath",
+ "epaint",
  "log",
  "nohash-hasher",
  "profiling",
+ "serde",
  "smallvec",
  "unicode-segmentation",
 ]
@@ -2586,7 +2535,7 @@ checksum = "e8e97625c2fe0fadc8b92ec690fbf515e15e2efd67ca50e063ad3302ec8ee626"
 dependencies = [
  "arboard",
  "bytemuck",
- "egui 0.34.2",
+ "egui",
  "log",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
@@ -2601,12 +2550,12 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01d34e845f01c62e3fded726961092e70417d66570c499b9817ab24674ca4ed"
+checksum = "8c609fc87f6c70ffd3afd679cbb294985096d2fc0be33e762ad5614bde4925bc"
 dependencies = [
  "ahash",
- "egui 0.33.3",
+ "egui",
  "enum-map",
  "image",
  "log",
@@ -2622,7 +2571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6caa4eca47cc2358e2c5ae60843a94118e338f87099c6af4170e6e968e8d77cb"
 dependencies = [
  "bytemuck",
- "egui 0.34.2",
+ "egui",
  "glow 0.17.0",
  "log",
  "memoffset",
@@ -2639,20 +2588,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491bdf728bf25ddd9ad60d4cf1c48588fa82c013a2440b91aa7fc43e34a07c32"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "emath"
 version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74fbbf7501c430b89df62d102b6bfa02162faaf3e155512c677c9d20f5708d1"
 dependencies = [
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -2800,49 +2741,26 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009d0dd3c2163823a0abdb899451ecbc78798dec545ee91b43aff1fa790bab62"
-dependencies = [
- "ab_glyph",
- "ahash",
- "ecolor 0.33.3",
- "emath 0.33.3",
- "epaint_default_fonts 0.33.3",
- "log",
- "nohash-hasher",
- "parking_lot",
- "profiling",
- "serde",
-]
-
-[[package]]
-name = "epaint"
 version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b452e348c2758115288802ca25f86ee286ce2cfae6643711ce116662311310"
 dependencies = [
  "ahash",
  "bytemuck",
- "ecolor 0.34.2",
- "emath 0.34.2",
- "epaint_default_fonts 0.34.2",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
  "font-types",
  "log",
  "nohash-hasher",
  "parking_lot",
  "profiling",
  "self_cell",
+ "serde",
  "skrifa",
  "smallvec",
  "vello_cpu",
 ]
-
-[[package]]
-name = "epaint_default_fonts"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fbe202b6578d3d56428fa185cdf114a05e49da05f477b3c7f0fbb221f1862"
 
 [[package]]
 name = "epaint_default_fonts"
@@ -3065,6 +2983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -5474,15 +5393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owned_ttf_parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
-dependencies = [
- "ttf-parser",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6949,6 +6859,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -7963,12 +7876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "ttf-parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-
-[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8222,6 +8129,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -9486,7 +9394,7 @@ dependencies = [
  "cron",
  "crossterm",
  "eframe",
- "egui 0.33.3",
+ "egui",
  "egui_extras",
  "flate2",
  "futures-util",

--- a/src/main_egui.rs
+++ b/src/main_egui.rs
@@ -5,40 +5,80 @@
 //! Or build: cargo build --features egui-standalone --release --bin xavier-gui
 
 use eframe::egui;
-use xavier::ui::KanbanState;
+use xavier::ui::{ConfigView, KanbanState};
 
 fn main() -> eframe::Result<()> {
+    // Parse arguments
+    let args: Vec<String> = std::env::args().collect();
+    let is_config_mode = args.iter().any(|arg| arg == "--config");
+
     // Configure native options for desktop
     let mut native_options = eframe::NativeOptions::default();
-    native_options.viewport.title = Some("Xavier - Kanban Board".to_string());
-    native_options.viewport.inner_size = Some(egui::vec2(1200.0, 800.0));
-    native_options.viewport.min_inner_size = Some(egui::vec2(800.0, 600.0));
+
+    if is_config_mode {
+        native_options.viewport.title = Some("Xavier Configuration".to_string());
+        native_options.viewport.inner_size = Some(egui::vec2(400.0, 450.0));
+        native_options.viewport.resizable = Some(false);
+        native_options.viewport.decorated = Some(false);
+        native_options.viewport.always_on_top = Some(true);
+    } else {
+        native_options.viewport.title = Some("Xavier - Kanban Board".to_string());
+        native_options.viewport.inner_size = Some(egui::vec2(1200.0, 800.0));
+        native_options.viewport.min_inner_size = Some(egui::vec2(800.0, 600.0));
+    }
 
     // Run the application
     eframe::run_native(
         "Xavier",
         native_options,
-        Box::new(|_cc| Ok(Box::new(XavierApp::new()))),
+        Box::new(move |_cc| Ok(Box::new(XavierApp::new(is_config_mode)))),
     )
 }
 
 /// Main application struct
 struct XavierApp {
     state: KanbanState,
+    config_view: ConfigView,
+    is_config_mode: bool,
 }
 
 impl XavierApp {
-    fn new() -> Self {
+    fn new(is_config_mode: bool) -> Self {
         Self {
             state: KanbanState::new(),
+            config_view: ConfigView::new(),
+            is_config_mode,
         }
     }
 }
 
 impl eframe::App for XavierApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // Update state and render
-        self.state.render(ctx);
+    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+        if self.is_config_mode {
+            egui::CentralPanel::default()
+                .frame(egui::Frame::window(&ctx.style()).fill(egui::Color32::from_rgb(10, 10, 10)))
+                .show(ctx, |ui| {
+                // Drag the window by clicking anywhere in the background
+                if ui.interact(ui.max_rect(), ui.id(), egui::Sense::drag()).dragged() {
+                    frame.drag_window();
+                }
+
+                ui.vertical(|ui| {
+                    ui.horizontal(|ui| {
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            if ui.button("X").clicked() {
+                                frame.close();
+                            }
+                        });
+                    });
+
+                    self.config_view.render(ui);
+                });
+            });
+        } else {
+            // Update state and render main Kanban board
+            self.state.render(ctx);
+        }
 
         // Request repaint for animations
         ctx.request_repaint();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,11 +1,11 @@
 use std::{fs, path::PathBuf};
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 const DEFAULT_CONFIG_PATH: &str = "config/xavier.config.json";
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct XavierSettings {
     #[serde(default)]
     pub server: ServerSettings,
@@ -21,10 +21,11 @@ pub struct XavierSettings {
     pub sync: SyncSettings,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerSettings {
     pub host: String,
     pub port: u16,
+    pub token: Option<String>,
     pub log_level: String,
     pub code_graph_db_path: String,
 }
@@ -34,13 +35,14 @@ impl Default for ServerSettings {
         Self {
             host: "127.0.0.1".to_string(),
             port: 8006,
+            token: None,
             log_level: "info".to_string(),
             code_graph_db_path: "data/code_graph.db".to_string(),
         }
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceSettings {
     pub default_workspace_id: String,
     pub default_plan: String,
@@ -67,7 +69,7 @@ impl Default for WorkspaceSettings {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemorySettings {
     pub backend: String,
     pub data_dir: String,
@@ -92,7 +94,7 @@ impl Default for MemorySettings {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelSettings {
     pub provider: String,
     pub api_flavor: String,
@@ -119,7 +121,7 @@ impl Default for ModelSettings {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RetrievalSettings {
     pub disable_hyde: bool,
 }
@@ -130,7 +132,7 @@ impl Default for RetrievalSettings {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncSettings {
     pub interval_ms: u64,
     pub lag_threshold_ms: u64,
@@ -263,6 +265,27 @@ impl XavierSettings {
             "XAVIER_SYNC_RETRY_DELAY_MS",
             &self.sync.retry_delay_ms.to_string(),
         );
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = std::env::var("XAVIER_CONFIG_PATH")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(DEFAULT_CONFIG_PATH));
+
+        // Ensure directory exists
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create config directory at {}", parent.display())
+            })?;
+        }
+
+        let serialized = serde_json::to_string_pretty(self)
+            .with_context(|| "failed to serialize settings to JSON")?;
+
+        fs::write(&path, serialized)
+            .with_context(|| format!("failed to write config file at {}", path.display()))?;
+
+        Ok(())
     }
 
     pub fn current() -> Self {

--- a/src/ui/config.rs
+++ b/src/ui/config.rs
@@ -1,0 +1,111 @@
+//! Configuration UI - Form for editing Xavier settings
+
+use crate::settings::XavierSettings;
+use egui::*;
+
+pub struct ConfigView {
+    /// Local copy of settings to allow cancelling
+    settings: XavierSettings,
+    /// Status message for the user
+    status_message: String,
+    /// Message color
+    status_color: Color32,
+}
+
+impl ConfigView {
+    pub fn new() -> Self {
+        Self {
+            settings: XavierSettings::current(),
+            status_message: String::new(),
+            status_color: Color32::GRAY,
+        }
+    }
+
+    /// Render the configuration form
+    pub fn render(&mut self, ui: &mut Ui) {
+        // Apply Mint Green LED styling
+        let mint_green = Color32::from_rgb(0, 255, 65);
+        let dark_bg = Color32::from_rgb(10, 10, 10);
+
+        ui.visuals_mut().override_text_color = Some(mint_green);
+        ui.visuals_mut().widgets.noninteractive.bg_fill = dark_bg;
+        ui.visuals_mut().widgets.inactive.bg_fill = dark_bg;
+
+        ui.vertical_centered(|ui| {
+            ui.heading(RichText::new("Xavier Configuration").color(mint_green).strong());
+        });
+
+        ui.add_space(20.0);
+
+        egui::Grid::new("config_grid")
+            .num_columns(2)
+            .spacing([20.0, 10.0])
+            .show(ui, |ui| {
+                // Server Port
+                ui.label("API Port:");
+                ui.add(egui::DragValue::new(&mut self.settings.server.port).range(1024..=65535));
+                ui.end_row();
+
+                // Workspace ID
+                ui.label("Workspace ID:");
+                ui.text_edit_singleline(&mut self.settings.workspace.default_workspace_id);
+                ui.end_row();
+
+                // Auth Token
+                ui.label("Auth Token:");
+                let mut token_str = self.settings.server.token.clone().unwrap_or_default();
+                if ui.text_edit_singleline(&mut token_str).changed() {
+                    self.settings.server.token = if token_str.is_empty() {
+                        None
+                    } else {
+                        Some(token_str)
+                    };
+                }
+                ui.end_row();
+
+                // Log Level
+                ui.label("Log Level:");
+                egui::ComboBox::from_id_source("log_level")
+                    .selected_text(&self.settings.server.log_level)
+                    .show_ui(ui, |ui| {
+                        ui.selectable_value(&mut self.settings.server.log_level, "trace".into(), "Trace");
+                        ui.selectable_value(&mut self.settings.server.log_level, "debug".into(), "Debug");
+                        ui.selectable_value(&mut self.settings.server.log_level, "info".into(), "Info");
+                        ui.selectable_value(&mut self.settings.server.log_level, "warn".into(), "Warn");
+                        ui.selectable_value(&mut self.settings.server.log_level, "error".into(), "Error");
+                    });
+                ui.end_row();
+            });
+
+        ui.add_space(30.0);
+
+        ui.horizontal(|ui| {
+            if ui.button(RichText::new("Save Changes").color(Color32::BLACK).strong())
+                .fill(mint_green)
+                .clicked()
+            {
+                match self.settings.save() {
+                    Ok(_) => {
+                        self.status_message = "Settings saved successfully!".to_string();
+                        self.status_color = mint_green;
+                    }
+                    Err(e) => {
+                        self.status_message = format!("Error saving: {}", e);
+                        self.status_color = Color32::LIGHT_RED;
+                    }
+                }
+            }
+
+            if ui.button("Reload").clicked() {
+                self.settings = XavierSettings::current();
+                self.status_message = "Settings reloaded.".to_string();
+                self.status_color = Color32::GRAY;
+            }
+        });
+
+        if !self.status_message.is_empty() {
+            ui.add_space(10.0);
+            ui.label(RichText::new(&self.status_message).color(self.status_color));
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,6 +20,8 @@ pub mod board;
 pub mod card;
 #[cfg(feature = "egui")]
 pub mod state;
+#[cfg(feature = "egui")]
+pub mod config;
 
 #[cfg(feature = "cli-interactive")]
 pub mod dashboard;
@@ -34,3 +36,5 @@ pub use board::BoardView;
 pub use card::CardView;
 #[cfg(feature = "egui")]
 pub use state::{EguiState, KanbanState};
+#[cfg(feature = "egui")]
+pub use config::ConfigView;

--- a/tests/settings_persistence_test.rs
+++ b/tests/settings_persistence_test.rs
@@ -1,0 +1,24 @@
+use xavier::settings::XavierSettings;
+use tempfile::tempdir;
+use std::env;
+
+#[test]
+fn test_settings_save_and_load() {
+    let dir = tempdir().unwrap();
+    let config_path = dir.path().join("xavier.config.json");
+    env::set_var("XAVIER_CONFIG_PATH", config_path.clone());
+
+    let mut settings = XavierSettings::default();
+    settings.server.port = 9999;
+    settings.server.token = Some("test-token".to_string());
+    settings.workspace.default_workspace_id = "test-ws".to_string();
+
+    settings.save().expect("Failed to save settings");
+
+    assert!(config_path.exists());
+
+    let loaded = XavierSettings::load().expect("Failed to load settings").expect("Settings should exist");
+    assert_eq!(loaded.server.port, 9999);
+    assert_eq!(loaded.server.token, Some("test-token".to_string()));
+    assert_eq!(loaded.workspace.default_workspace_id, "test-ws");
+}


### PR DESCRIPTION
This PR implements a floating, frameless configuration window for Xavier using egui and eframe. 

Key changes:
- **Settings Persistence**: Updated `src/settings.rs` to allow saving configuration changes back to `config/xavier.config.json`. Added a `token` field to support auth token configuration via the UI.
- **Configuration UI**: Added `src/ui/config.rs` containing the `ConfigView`. This view provides form fields for port, workspace ID, auth token, and log level, styled with the project's 'Mint Green LED' aesthetic.
- **CLI Integration**: Modified `src/main_egui.rs` to detect a `--config` flag. When present, the app launches in a specialized mode with a frameless, always-on-top window.
- **Testing**: Added `tests/settings_persistence_test.rs` to verify that settings are correctly serialized and deserialized from disk.

This feature allows users to quickly modify Xavier's core settings without needing to manually edit JSON files or use a terminal.

Fixes #204

---
*PR created automatically by Jules for task [15035776922113683555](https://jules.google.com/task/15035776922113683555) started by @iberi22*