### PR TITLE
Implement Change Control Domain Types

### DIFF
--- a/src/domain/change_control/conflict.rs
+++ b/src/domain/change_control/conflict.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+/// Represents a detected conflict between multiple agent tasks or system policies.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConflictReport {
+    pub task_id: String,
+    pub conflicting_task_id: Option<String>,
+    pub conflict_type: ConflictType,
+    pub files: Vec<String>,
+    pub contracts: Vec<String>,
+    pub severity: String,
+    pub recommendation: String,
+}
+
+/// The type of conflict detected.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ConflictType {
+    DirectFileOverlap,
+    ContractBreach,
+    DependencyConflict,
+    BlockedByPolicy,
+}

--- a/src/domain/change_control/lease.rs
+++ b/src/domain/change_control/lease.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+
+/// Represents a temporary reservation of file patterns by an agent for a specific task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileLease {
+    pub id: String,
+    pub task_id: String,
+    pub agent_id: String,
+    pub patterns: Vec<String>,
+    pub mode: LeaseMode,
+    pub expires_at: DateTime<Utc>,
+    pub status: LeaseStatus,
+}
+
+/// The mode of the file lease, defining what the agent is allowed to do.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LeaseMode {
+    Read,
+    Write,
+    Block,
+}
+
+/// The lifecycle status of a FileLease.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LeaseStatus {
+    Active,
+    Expired,
+    Released,
+}

--- a/src/domain/change_control/mod.rs
+++ b/src/domain/change_control/mod.rs
@@ -1,0 +1,18 @@
+pub mod conflict;
+pub mod lease;
+pub mod scope;
+pub mod task;
+
+pub use conflict::{ConflictReport, ConflictType};
+pub use lease::{FileLease, LeaseMode, LeaseStatus};
+pub use scope::ChangeScope;
+pub use task::{AgentTask, AgentTaskStatus};
+
+/// List of high-risk paths that require strict change control.
+pub const CRITICAL_FILES: &[&str] = &[
+    "Cargo.toml",
+    "src/lib.rs",
+    "src/main.rs",
+    "src/server/mod.rs",
+    "src/domain/mod.rs",
+];

--- a/src/domain/change_control/scope.rs
+++ b/src/domain/change_control/scope.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+/// Defines the operational boundaries for an agent's change task.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ChangeScope {
+    /// List of file patterns (globs) that the agent is allowed to modify.
+    pub allowed_write: Vec<String>,
+    /// List of file patterns (globs) that the agent can only read.
+    pub read_only: Vec<String>,
+    /// List of file patterns (globs) that the agent is strictly prohibited from accessing.
+    pub blocked: Vec<String>,
+    /// List of system contracts or interfaces that might be affected by the changes.
+    pub contracts_affected: Vec<String>,
+    /// List of architectural layers affected by the changes.
+    pub layers_affected: Vec<String>,
+}

--- a/src/domain/change_control/task.rs
+++ b/src/domain/change_control/task.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+use super::scope::ChangeScope;
+
+/// Represents a unit of work assigned to an agent that involves modifying the codebase.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentTask {
+    pub id: String,
+    pub title: String,
+    pub capability: String,
+    pub agent_id: Option<String>,
+    pub status: AgentTaskStatus,
+    pub intent: String,
+    pub scope: ChangeScope,
+    pub risk_level: String,
+    pub dependencies: Vec<String>,
+    pub memory_refs: Vec<String>,
+}
+
+/// The lifecycle status of an AgentTask.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentTaskStatus {
+    Draft,
+    Claimed,
+    Active,
+    Completed,
+    Failed,
+    Cancelled,
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod belief;
+pub mod change_control;
 pub mod memory;
 pub mod pattern;
 pub mod security;


### PR DESCRIPTION
Added pure domain types for the Agent Change Control Plane as specified in ADR-006. This includes `AgentTask`, `ChangeScope`, `FileLease`, and `ConflictReport` in the `src/domain/change_control/` module. These types follow hexagonal architecture principles and provide the foundation for governing agent modifications to the codebase.

Fixes #222

---
*PR created automatically by Jules for task [3534385678959629832](https://jules.google.com/task/3534385678959629832) started by @iberi22*