### PR TITLE
Change Control: Memory Consolidation (Phase 3)

### DIFF
--- a/src/app/change_control_service.rs
+++ b/src/app/change_control_service.rs
@@ -1,0 +1,95 @@
+use crate::domain::change_control::{LeaseRequest, LeaseResponse, TaskCompletionRequest};
+use crate::memory::schema::{MemoryKind, MemoryQueryFilters};
+use crate::memory::store::MemoryRecord;
+use crate::ports::inbound::{ChangeControlPort, MemoryQueryPort};
+use async_trait::async_trait;
+use std::sync::Arc;
+use ulid::Ulid;
+
+pub struct ChangeControlService {
+    memory: Arc<dyn MemoryQueryPort>,
+}
+
+impl ChangeControlService {
+    pub fn new(memory: Arc<dyn MemoryQueryPort>) -> Self {
+        Self { memory }
+    }
+}
+
+#[async_trait]
+impl ChangeControlPort for ChangeControlService {
+    async fn claim_lease(&self, request: LeaseRequest) -> anyhow::Result<LeaseResponse> {
+        let mut context = Vec::new();
+
+        // 1. Search relevant decisions for affected files
+        for file in &request.files_affected {
+            let filters = MemoryQueryFilters {
+                kinds: Some(vec![MemoryKind::Decision]),
+                file_path: Some(file.clone()),
+                ..Default::default()
+            };
+            let results = self.memory.search(file, Some(filters)).await?;
+            for res in results {
+                context.push(serde_json::to_value(res)?);
+            }
+        }
+
+        // 2. Search agent_change_summary for similar past tasks
+        let summary_filters = MemoryQueryFilters {
+            kinds: Some(vec![MemoryKind::AgentChangeSummary]),
+            ..Default::default()
+        };
+        let similar_summaries = self.memory.search(&request.task_description, Some(summary_filters)).await?;
+        for res in similar_summaries {
+            context.push(serde_json::to_value(res)?);
+        }
+
+        // 3. Search conflict history
+        let conflict_filters = MemoryQueryFilters {
+            kinds: Some(vec![MemoryKind::AgentChangeSummary]),
+            ..Default::default()
+        };
+        let conflicts = self.memory.search("conflict", Some(conflict_filters)).await?;
+        for res in conflicts {
+            context.push(serde_json::to_value(res)?);
+        }
+
+        Ok(LeaseResponse {
+            lease_id: Ulid::new().to_string(),
+            memory_context: context,
+        })
+    }
+
+    async fn complete_task(&self, request: TaskCompletionRequest) -> anyhow::Result<String> {
+        let metadata = serde_json::json!({
+            "type": "agent_change_summary",
+            "task_id": request.task_id,
+            "agent_id": request.agent_id,
+            "files_changed": request.files_changed,
+            "contracts_affected": request.contracts_affected,
+            "risk_level": request.risk_level,
+            "checks_passed": request.checks_passed,
+            "pr": request.pr_link,
+        });
+
+        let record = MemoryRecord {
+            id: String::new(),
+            workspace_id: "default".to_string(), // TODO: Get workspace_id from context
+            path: request.path,
+            content: request.content,
+            metadata,
+            embedding: Vec::new(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            revision: 1,
+            primary: true,
+            parent_id: None,
+            cluster_id: None,
+            level: crate::memory::schema::MemoryLevel::Raw,
+            relation: None,
+            revisions: Vec::new(),
+        };
+
+        self.memory.add(record).await
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+pub mod change_control_service;
 pub mod health_service;
 pub mod pattern_service;
 pub mod qmd_memory_adapter;

--- a/src/domain/change_control.rs
+++ b/src/domain/change_control.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LeaseRequest {
+    pub agent_id: String,
+    pub files_affected: Vec<String>,
+    pub task_description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LeaseResponse {
+    pub lease_id: String,
+    pub memory_context: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskCompletionRequest {
+    pub agent_id: String,
+    pub task_id: String,
+    pub path: String,
+    pub content: String,
+    pub files_changed: Vec<String>,
+    pub contracts_affected: Vec<String>,
+    pub risk_level: String,
+    pub checks_passed: Vec<String>,
+    pub pr_link: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentChangeSummary {
+    pub task_id: String,
+    pub agent_id: String,
+    pub files_changed: Vec<String>,
+    pub contracts_affected: Vec<String>,
+    pub risk_level: String,
+    pub checks_passed: Vec<String>,
+    pub pr: Option<String>,
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod belief;
+pub mod change_control;
 pub mod memory;
 pub mod pattern;
 pub mod security;

--- a/src/memory/schema.rs
+++ b/src/memory/schema.rs
@@ -29,6 +29,7 @@ pub enum MemoryKind {
     ContentProject,
     VideoAsset,
     Document,
+    AgentChangeSummary,
 }
 
 impl MemoryKind {
@@ -57,6 +58,7 @@ impl MemoryKind {
             "content_project" | "content-project" | "content project" => Some(Self::ContentProject),
             "video_asset" | "video-asset" | "video asset" => Some(Self::VideoAsset),
             "document" | "memory" | "note" => Some(Self::Document),
+            "agent_change_summary" | "agent-change-summary" => Some(Self::AgentChangeSummary),
             _ => None,
         }
     }
@@ -86,6 +88,7 @@ impl MemoryKind {
             Self::ContentProject => "content_project",
             Self::VideoAsset => "video_asset",
             Self::Document => "document",
+            Self::AgentChangeSummary => "agent_change_summary",
         }
     }
 }

--- a/src/ports/inbound/change_control_port.rs
+++ b/src/ports/inbound/change_control_port.rs
@@ -1,0 +1,8 @@
+use crate::domain::change_control::{LeaseRequest, LeaseResponse, TaskCompletionRequest};
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait ChangeControlPort: Send + Sync {
+    async fn claim_lease(&self, request: LeaseRequest) -> anyhow::Result<LeaseResponse>;
+    async fn complete_task(&self, request: TaskCompletionRequest) -> anyhow::Result<String>;
+}

--- a/src/ports/inbound/mod.rs
+++ b/src/ports/inbound/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent_lifecycle_port;
+pub mod change_control_port;
 pub mod health_port;
 pub mod input_security_port;
 pub mod memory_port;
@@ -10,6 +11,7 @@ pub mod time_metrics_port;
 pub mod verification_port;
 
 pub use agent_lifecycle_port::AgentLifecyclePort;
+pub use change_control_port::ChangeControlPort;
 pub use health_port::{HealthPort, HealthStatus as InboundHealthStatus};
 pub use input_security_port::InputSecurityPort;
 pub use memory_port::MemoryQueryPort;


### PR DESCRIPTION
I have implemented the core logic for Agent Change Control as part of ADR-006 Phase 3. 

Key changes include:
1. **Schema Update**: Added `AgentChangeSummary` to `MemoryKind` in `src/memory/schema.rs` to track completed agent tasks.
2. **Domain Models**: Introduced `LeaseRequest`, `LeaseResponse`, and `TaskCompletionRequest` in `src/domain/change_control.rs`.
3. **Inbound Port**: Defined `ChangeControlPort` in `src/ports/inbound/change_control_port.rs` to abstract the change control operations.
4. **Service Implementation**: Created `ChangeControlService` in `src/app/change_control_service.rs`.
   - `claim_lease`: Implements "READ before WRITE" by aggregating relevant context (decisions, past summaries, conflicts) based on affected files and task description.
   - `complete_task`: Implements "WRITE after COMPLETE" by storing a structured `AgentChangeSummary` in the memory store.
5. **Architectural Integration**: Exported the new components in `src/domain/mod.rs`, `src/ports/inbound/mod.rs`, and `src/app/mod.rs`.

I have verified the code structure and basic logic, ensuring it follows the hexagonal architecture of the project.

Fixes #226

---
*PR created automatically by Jules for task [17357801643324341285](https://jules.google.com/task/17357801643324341285) started by @iberi22*