### PR TITLE
Implement Change Control Policy Engine (ADR-006 Phase 2)

### DIFF
--- a/.gitcore/change-control.yaml
+++ b/.gitcore/change-control.yaml
@@ -1,0 +1,35 @@
+layers:
+  domain:
+    path: "src/domain/**"
+    risk: high
+    may_import: []
+
+  app:
+    path: "src/app/**"
+    risk: medium
+    may_import: [domain, ports]
+
+  ports:
+    path: "src/ports/**"
+    risk: high
+    may_import: [domain]
+
+  adapters:
+    path: "src/adapters/**"
+    risk: medium
+    may_import: [ports, app]
+
+critical_files:
+  - "src/memory/qmd_memory.rs"
+  - "src/domain/memory/**"
+  - "src/ports/inbound/memory_port.rs"
+  - ".gitcore/ARCHITECTURE.md"
+
+rules:
+  - id: domain_no_adapter_imports
+    description: "Domain cannot import adapters"
+    severity: error
+
+  - id: high_risk_requires_approval
+    description: "High-risk files require human or architect-agent approval"
+    severity: block

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9518,6 +9518,7 @@ dependencies = [
  "futures-util",
  "git2",
  "gllm",
+ "glob",
  "hex",
  "hmac",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ zerocopy = "0.8"
 
 # File traversal
 walkdir = "2"
+glob = "0.3"
 
 # egui - Native UI (optional, for web UI)
 egui = { version = "0.34.2", optional = true }

--- a/src/app/change_control_service.rs
+++ b/src/app/change_control_service.rs
@@ -1,0 +1,51 @@
+use crate::domain::change_control::{ChangePolicy, ValidationStatus};
+
+pub struct ChangeControlService {
+    policy: ChangePolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimResult {
+    Approved,
+    ApprovalRequired(String),
+    Rejected(String),
+}
+
+impl ChangeControlService {
+    pub fn new(policy: ChangePolicy) -> Self {
+        Self { policy }
+    }
+
+    pub fn load_default() -> Result<Self, crate::domain::change_control::ChangeControlError> {
+        let policy = ChangePolicy::load(".gitcore/change-control.yaml")?;
+        Ok(Self::new(policy))
+    }
+
+    pub fn validate_claim(&self, _agent_id: &str, resource_path: &str) -> ClaimResult {
+        if self.policy.is_critical(resource_path) {
+            return ClaimResult::ApprovalRequired(format!(
+                "Resource '{}' is critical and requires approval",
+                resource_path
+            ));
+        }
+
+        if let Some((name, rule)) = self.policy.get_layer_for_path(resource_path) {
+            if rule.risk == crate::domain::change_control::RiskLevel::High {
+                return ClaimResult::ApprovalRequired(format!(
+                    "Resource '{}' belongs to high-risk layer '{}' and requires approval",
+                    resource_path, name
+                ));
+            }
+        }
+
+        ClaimResult::Approved
+    }
+
+    pub fn validate_import(&self, from_path: &str, to_path: &str) -> ValidationStatus {
+        self.policy.validate_import(from_path, to_path)
+    }
+
+    pub fn policy(&self) -> &ChangePolicy {
+        &self.policy
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,3 +4,4 @@ pub mod qmd_memory_adapter;
 pub mod security_service;
 // pub mod session_service; // removed — types not available in current domain layout
 pub mod verification_service;
+pub mod change_control_service;

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -94,11 +94,12 @@ impl Coordinator {
     }
 }
 
+use crate::app::change_control_service::{ChangeControlService, ClaimResult};
+
 pub struct DistributedLock {
-    // TODO: Dead code - remove or expose the resource id in lock state reporting.
-    #[allow(dead_code)]
     resource_id: String,
     owner: RwLock<Option<String>>,
+    policy_engine: Option<Arc<ChangeControlService>>,
 }
 
 impl DistributedLock {
@@ -106,10 +107,34 @@ impl DistributedLock {
         Self {
             resource_id,
             owner: RwLock::new(None),
+            policy_engine: None,
+        }
+    }
+
+    pub fn with_policy(resource_id: String, policy_engine: Arc<ChangeControlService>) -> Self {
+        Self {
+            resource_id,
+            owner: RwLock::new(None),
+            policy_engine: Some(policy_engine),
         }
     }
 
     pub async fn try_acquire(&self, owner: &str) -> bool {
+        // If policy engine exists, validate the claim first
+        if let Some(ref engine) = self.policy_engine {
+            match engine.validate_claim(owner, &self.resource_id) {
+                ClaimResult::Approved => {}
+                ClaimResult::ApprovalRequired(reason) => {
+                    tracing::warn!("Acquisition of '{}' requires approval: {}", self.resource_id, reason);
+                    return false;
+                }
+                ClaimResult::Rejected(reason) => {
+                    tracing::warn!("Acquisition of '{}' rejected: {}", self.resource_id, reason);
+                    return false;
+                }
+            }
+        }
+
         let mut current = self.owner.write().await;
         if current.is_none() {
             *current = Some(owner.to_string());

--- a/src/domain/change_control/mod.rs
+++ b/src/domain/change_control/mod.rs
@@ -1,0 +1,3 @@
+pub mod policy;
+
+pub use policy::*;

--- a/src/domain/change_control/policy.rs
+++ b/src/domain/change_control/policy.rs
@@ -1,0 +1,115 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use serde::{Deserialize, Serialize};
+use glob::Pattern;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ChangeControlError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("YAML error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+    #[error("Invalid pattern: {0}")]
+    Pattern(#[from] glob::PatternError),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChangePolicy {
+    pub layers: HashMap<String, LayerRule>,
+    pub critical_files: Vec<String>,
+    pub rules: Vec<ValidationRule>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LayerRule {
+    pub path: String,
+    pub risk: RiskLevel,
+    pub may_import: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RiskLevel {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ValidationRule {
+    pub id: String,
+    pub description: String,
+    pub severity: Severity,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Block,
+    Warn,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationStatus {
+    Allowed,
+    Warn(String),
+    Rejected(String),
+}
+
+impl ChangePolicy {
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, ChangeControlError> {
+        let content = fs::read_to_string(path)?;
+        let policy: ChangePolicy = serde_yaml::from_str(&content)?;
+        Ok(policy)
+    }
+
+    pub fn is_critical(&self, path: &str) -> bool {
+        for pattern_str in &self.critical_files {
+            if let Ok(pattern) = Pattern::new(pattern_str) {
+                if pattern.matches(path) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn get_layer_for_path(&self, path: &str) -> Option<(String, &LayerRule)> {
+        for (name, rule) in &self.layers {
+            if let Ok(pattern) = Pattern::new(&rule.path) {
+                if pattern.matches(path) {
+                    return Some((name.clone(), rule));
+                }
+            }
+        }
+        None
+    }
+
+    pub fn validate_import(&self, from_path: &str, to_path: &str) -> ValidationStatus {
+        let from_layer = match self.get_layer_for_path(from_path) {
+            Some((name, rule)) => (name, rule),
+            None => return ValidationStatus::Allowed,
+        };
+
+        let to_layer = match self.get_layer_for_path(to_path) {
+            Some((name, _)) => name,
+            None => return ValidationStatus::Allowed,
+        };
+
+        if from_layer.0 == to_layer {
+            return ValidationStatus::Allowed;
+        }
+
+        if from_layer.1.may_import.contains(&to_layer) {
+            ValidationStatus::Allowed
+        } else {
+            ValidationStatus::Rejected(format!(
+                "Layer '{}' is not allowed to import from layer '{}'",
+                from_layer.0, to_layer
+            ))
+        }
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -3,3 +3,4 @@ pub mod belief;
 pub mod memory;
 pub mod pattern;
 pub mod security;
+pub mod change_control;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,6 +8,8 @@ mod a2a_test;
 mod agents_test;
 #[path = "integration/belief_graph_test.rs"]
 mod belief_graph_test;
+#[path = "integration/change_control_test.rs"]
+mod change_control_test;
 #[path = "integration/checkpoint_test.rs"]
 mod checkpoint_test;
 #[path = "integration/cli.rs"]

--- a/tests/integration/change_control_test.rs
+++ b/tests/integration/change_control_test.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+use xavier::domain::change_control::{ChangePolicy, ValidationStatus};
+use xavier::app::change_control_service::ChangeControlService;
+use xavier::coordination::DistributedLock;
+
+#[tokio::test]
+async fn test_policy_load_and_validation() {
+    let yaml = r#"
+layers:
+  domain:
+    path: "src/domain/**"
+    risk: high
+    may_import: []
+  adapters:
+    path: "src/adapters/**"
+    risk: medium
+    may_import: [ports]
+critical_files:
+  - "src/memory/qmd_memory.rs"
+rules:
+  - id: test_rule
+    description: "test"
+    severity: error
+"#;
+    let policy: ChangePolicy = serde_yaml::from_str(yaml).unwrap();
+
+    // Test critical files
+    assert!(policy.is_critical("src/memory/qmd_memory.rs"));
+    assert!(!policy.is_critical("src/other.rs"));
+
+    // Test layer detection
+    let layer = policy.get_layer_for_path("src/domain/mod.rs");
+    assert!(layer.is_some());
+    assert_eq!(layer.unwrap().0, "domain");
+
+    // Test import validation
+    let status = policy.validate_import("src/domain/mod.rs", "src/adapters/mod.rs");
+    match status {
+        ValidationStatus::Rejected(reason) => assert!(reason.contains("is not allowed to import")),
+        _ => panic!("Expected rejection"),
+    }
+}
+
+#[tokio::test]
+async fn test_distributed_lock_with_policy() {
+    let yaml = r#"
+layers:
+  domain:
+    path: "src/domain/**"
+    risk: high
+    may_import: []
+critical_files:
+  - "src/memory/qmd_memory.rs"
+rules: []
+"#;
+    let policy: ChangePolicy = serde_yaml::from_str(yaml).unwrap();
+    let service = Arc::new(ChangeControlService::new(policy));
+
+    // Lock on critical file should fail (ApprovalRequired)
+    let lock_critical = DistributedLock::with_policy("src/memory/qmd_memory.rs".to_string(), service.clone());
+    assert!(!lock_critical.try_acquire("agent1").await);
+
+    // Lock on high-risk layer should fail (ApprovalRequired)
+    let lock_high_risk = DistributedLock::with_policy("src/domain/agent.rs".to_string(), service.clone());
+    assert!(!lock_high_risk.try_acquire("agent1").await);
+
+    // Lock on normal file should succeed
+    let lock_normal = DistributedLock::with_policy("src/utils/mod.rs".to_string(), service.clone());
+    assert!(lock_normal.try_acquire("agent1").await);
+}


### PR DESCRIPTION
This PR implements the executable architectural policy engine defined in ADR-006 Phase 2.

### Key Changes:
- **Policy Configuration**: Created `.gitcore/change-control.yaml` defining layers (domain, app, ports, adapters) and critical files.
- **Domain Logic**: Implemented `ChangePolicy` to handle glob-based path matching, layer detection, and import validation.
- **Service Layer**: Added `ChangeControlService` to orchestrate policy loading and resource claim validation.
- **Coordination Integration**: Enhanced `DistributedLock` to optionally enforce policies during resource acquisition, supporting 'approval required' and 'rejected' states.
- **Testing**: Added a comprehensive integration test suite verifying layer import rules and critical file protections.

This enables automated enforcement of the project's hexagonal architecture and high-risk file change control.

Fixes #225

---
*PR created automatically by Jules for task [10652422512032531569](https://jules.google.com/task/10652422512032531569) started by @iberi22*