### PR TITLE
Unify memory backend for Gestalt Rust and Xavier2

### DIFF
--- a/src/adapters/inbound/http/handlers/agent.rs
+++ b/src/adapters/inbound/http/handlers/agent.rs
@@ -1,7 +1,7 @@
 use axum::{extract::State, Json};
 use serde::{Deserialize, Serialize};
 use crate::adapters::inbound::http::AppState;
-use xavier::coordination::agent_registry::AgentMetadata;
+use crate::domain::agent::AgentMetadata;
 
 #[derive(Debug, Deserialize)]
 pub struct AgentRegisterPayload {
@@ -20,6 +20,7 @@ pub async fn agent_register_handler(
         name: payload.name,
         capabilities: payload.capabilities.unwrap_or_default(),
         role: payload.role,
+        endpoint: None,
     };
 
     let success = state

--- a/src/adapters/inbound/http/handlers/memory.rs
+++ b/src/adapters/inbound/http/handlers/memory.rs
@@ -118,7 +118,23 @@ pub async fn add_handler(
     Json(payload): Json<AddPayload>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     check_auth(&headers, &state)?;
-    let mut record = DomainMemoryRecord::new_fact(payload.path.clone(), payload.content);
+    let mut record = DomainMemoryRecord {
+        id: String::new(),
+        workspace_id: state.workspace_id.clone(),
+        path: payload.path.clone(),
+        content: payload.content,
+        metadata: payload.metadata,
+        embedding: vec![],
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        revision: 1,
+        primary: true,
+        parent_id: None,
+        cluster_id: None,
+        level: crate::memory::schema::MemoryLevel::Raw,
+        relation: None,
+        revisions: vec![],
+    };
     // Note: domain metadata translation would go here if needed
 
     match state.memory.add(record).await {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,12 +42,34 @@ use xavier::security::{ProcessResult, SecurityService};
 use xavier::server::panel::{
     panel_asset, panel_index, CreateThreadRequest, PanelChatRequest, PanelChatResponse,
 };
+use xavier::server::v1_api::{
+    v1_memories_add, v1_memories_context, v1_memories_delete, v1_memories_get, v1_memories_list,
+    v1_memories_recent, v1_memories_search, v1_memories_update, v1_timeline_events,
+};
+use xavier::workspace::WorkspaceContext;
 use xavier::session::event_mapper::PanelThreadEntry;
 use xavier::session::types::SessionEvent;
 use xavier::tasks::session_sync_task::SessionSyncTask;
 use xavier::time::TimeMetricsStore;
 
 use crate::settings::XavierSettings;
+
+impl From<CliState> for xavier::AppState {
+    fn from(cli: CliState) -> Self {
+        Self {
+            workspace_registry: Arc::new(xavier::workspace::WorkspaceRegistry::new()), // Simplified
+            indexer: xavier::memory::file_indexer::FileIndexer::new(
+                xavier::memory::file_indexer::FileIndexerConfig::default(),
+                Some(cli.code_indexer.clone()),
+            ),
+            code_indexer: cli.code_indexer,
+            code_query: cli.code_query,
+            code_db: cli.code_db,
+            pattern_adapter: Arc::new(xavier::adapters::outbound::vec::pattern_adapter::PatternAdapter::new()),
+            security_service: Arc::new(xavier::app::security_service::SecurityService::new()),
+        }
+    }
+}
 
 /// CLI-specific application state with direct memory store access
 #[derive(Clone)]
@@ -257,6 +279,7 @@ impl Cli {
 }
 
 async fn start_http_server(port: u16) -> Result<()> {
+    use xavier::agents::RuntimeConfig;
     std::env::set_var("XAVIER_PORT", port.to_string());
 
     // Set default router model assignments (user can override via env)
@@ -404,6 +427,17 @@ async fn start_http_server(port: u16) -> Result<()> {
         .route("/xavier/sync/check", post(sync_check_handler))
         .route("/xavier/sync/check", get(sync_check_handler))
         .route("/xavier/verify/save", post(verify_save_handler))
+        .route("/v1/memories", post(v1_memories_add).get(v1_memories_list))
+        .route(
+            "/v1/memories/{id}",
+            get(v1_memories_get)
+                .put(v1_memories_update)
+                .delete(v1_memories_delete),
+        )
+        .route("/v1/memories/search", post(v1_memories_search))
+        .route("/v1/memories/recent", get(v1_memories_recent))
+        .route("/v1/memories/context", post(v1_memories_context))
+        .route("/v1/timeline/events", get(v1_timeline_events))
         .route(
             "/panel/api/threads",
             get(panel_list_threads).post(panel_create_thread),
@@ -445,8 +479,28 @@ async fn start_http_server(port: u16) -> Result<()> {
         .route("/readiness", get(readiness_handler))
         .route("/panel", get(panel_index))
         .route("/panel/assets/{*path}", get(panel_asset))
+        .route("/v1/events", get(move |s, w| xavier::server::http::ws_events_handler(w, s)).with_state(xavier::AppState::from(state.clone())))
         .merge(change_control_routes)
         .merge(protected_routes)
+        .layer(axum::Extension(WorkspaceContext {
+            workspace_id: state.workspace_id.clone(),
+            workspace: Arc::new(xavier::workspace::WorkspaceState::new(
+                xavier::workspace::WorkspaceConfig {
+                    id: state.workspace_id.clone(),
+                    token: token.clone(),
+                    plan: xavier::workspace::PlanTier::Pro,
+                    memory_backend: xavier::memory::store::MemoryBackend::Vec,
+                    storage_limit_bytes: None,
+                    request_limit: None,
+                    request_unit_limit: None,
+                    embedding_provider_mode: xavier::workspace::EmbeddingProviderMode::BringYourOwn,
+                    managed_google_embeddings: false,
+                    sync_policy: xavier::workspace::SyncPolicy::LocalOnly,
+                },
+                RuntimeConfig::default(),
+                state.workspace_dir.clone(),
+            ).await?),
+        }))
         .with_state(state.clone());
 
     let listener = TcpListener::bind(&bind_addr).await?;

--- a/src/domain/agent.rs
+++ b/src/domain/agent.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Active agent entry tracked by the lifecycle registry.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentEntry {
     pub agent_id: String,
     pub session_id: String,

--- a/src/memory/schema.rs
+++ b/src/memory/schema.rs
@@ -226,6 +226,7 @@ pub struct MemoryProvenance {
     pub recorded_at: Option<String>,
     pub topic_key: Option<String>,
     pub tool_name: Option<String>,
+    pub chunk_id: Option<String>,
     // Hierarchy fields
     pub level: Option<MemoryLevel>,
     pub parent_id: Option<String>,
@@ -260,6 +261,7 @@ pub struct MemoryQueryFilters {
     pub url: Option<String>,
     pub message_id: Option<String>,
     pub topic_key: Option<String>,
+    pub chunk_id: Option<String>,
     pub observed_after: Option<String>,
     pub observed_before: Option<String>,
     pub recorded_after: Option<String>,
@@ -474,6 +476,12 @@ pub fn matches_filters(
     ) {
         return false;
     }
+    if !matches_string_filter(
+        filters.chunk_id.as_deref(),
+        resolved.provenance.chunk_id.as_deref(),
+    ) {
+        return false;
+    }
 
     if !matches_time_window(
         resolved.provenance.observed_at.as_deref(),
@@ -636,6 +644,10 @@ fn overlay_provenance(provenance: &mut MemoryProvenance, metadata: &Value, path:
         .tool_name
         .take()
         .or_else(|| string_value(metadata, "tool_name"));
+    provenance.chunk_id = provenance
+        .chunk_id
+        .take()
+        .or_else(|| string_value(metadata, "chunk_id"));
 
     // Hierarchy overlays
     provenance.level = provenance

--- a/src/memory/sqlite_vec_store.rs
+++ b/src/memory/sqlite_vec_store.rs
@@ -2705,6 +2705,9 @@ mod tests {
                     revision INTEGER NOT NULL DEFAULT 1,
                     primary_flag INTEGER NOT NULL DEFAULT 1,
                     parent_id TEXT,
+                    cluster_id TEXT,
+                    level TEXT NOT NULL DEFAULT 'raw',
+                    relation TEXT,
                     revisions TEXT NOT NULL DEFAULT '[]'
                 );
                 CREATE VIRTUAL TABLE memory_fts USING fts5(

--- a/src/server/v1_api.rs
+++ b/src/server/v1_api.rs
@@ -5,6 +5,7 @@ use axum::{
     response::IntoResponse,
     Extension, Json,
 };
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -35,6 +36,7 @@ pub struct V1AddMemoryRequest {
     pub evidence_kind: Option<EvidenceKind>,
     pub namespace: Option<MemoryNamespace>,
     pub provenance: Option<MemoryProvenance>,
+    pub importance: Option<f32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -107,6 +109,19 @@ pub async fn v1_memories_add(
         .clone()
         .unwrap_or_else(|| "default".to_string());
     let mut meta = payload.metadata.unwrap_or(serde_json::json!({}));
+
+    if let Some(importance) = payload.importance {
+        let priority = match importance {
+            i if i >= 0.9 => "critical",
+            i if i >= 0.7 => "high",
+            i if i >= 0.4 => "medium",
+            i if i >= 0.1 => "low",
+            _ => "ephemeral",
+        };
+        meta["memory_priority"] = serde_json::json!(priority);
+        meta["importance"] = serde_json::json!(importance);
+    }
+
     let mut namespace = payload.namespace;
     if let Some(uid) = payload.user_id {
         meta["user_id"] = serde_json::json!(uid);
@@ -346,6 +361,127 @@ pub async fn v1_memories_update(
         Err(error) => Json(serde_json::json!({
             "status": "error",
             "message": error.to_string()
+        })),
+    }
+}
+
+pub async fn v1_memories_recent(
+    Extension(workspace): Extension<WorkspaceContext>,
+    Query(params): Query<V1PaginationParams>,
+) -> impl IntoResponse {
+    let limit = params.limit.unwrap_or(10);
+
+    let mut all_docs = workspace.workspace.memory.all_documents().await;
+    all_docs.sort_by(|a, b| {
+        let get_ts = |doc: &crate::memory::qmd_memory::MemoryDocument| {
+            doc.metadata
+                .get("updated_at")
+                .and_then(|v| v.as_str())
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(Utc::now)
+        };
+        get_ts(b).cmp(&get_ts(a))
+    });
+
+    let memories: Vec<_> = all_docs
+        .into_iter()
+        .filter(|doc| is_primary_memory(&doc.metadata))
+        .take(limit)
+        .map(|doc| V1MemoryResponse {
+            id: doc.id.unwrap_or_default(),
+            memory: doc.content,
+            user_id: Some(doc.path),
+            metadata: doc.metadata,
+        })
+        .collect();
+
+    Json(serde_json::json!({
+        "status": "ok",
+        "memories": memories,
+    }))
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V1ContextRequest {
+    pub query: String,
+    pub limit: Option<usize>,
+    pub max_chars: Option<usize>,
+    pub filters: Option<MemoryQueryFilters>,
+}
+
+pub async fn v1_memories_context(
+    Extension(workspace): Extension<WorkspaceContext>,
+    Json(payload): Json<V1ContextRequest>,
+) -> impl IntoResponse {
+    let limit = payload.limit.unwrap_or(10);
+    let max_chars = payload.max_chars.unwrap_or(4000);
+
+    let results = query_with_embedding_filtered(
+        &workspace.workspace.memory,
+        &payload.query,
+        limit,
+        payload.filters.as_ref(),
+    )
+    .await
+    .unwrap_or_default();
+
+    let mut context_parts = Vec::new();
+    let mut current_chars = 0;
+
+    for doc in results {
+        if !is_primary_memory(&doc.metadata) {
+            continue;
+        }
+
+        let part = format!("[{}] {}\n", doc.path, doc.content);
+        if current_chars + part.len() > max_chars && !context_parts.is_empty() {
+            break;
+        }
+        current_chars += part.len();
+        context_parts.push(part);
+    }
+
+    let context_string = context_parts.join("\n---\n");
+
+    Json(serde_json::json!({
+        "status": "ok",
+        "context": context_string,
+        "tokens_estimate": current_chars / 4,
+    }))
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct V1TimelineEventsParams {
+    pub since: Option<String>,
+    pub limit: Option<usize>,
+}
+
+pub async fn v1_timeline_events(
+    Extension(workspace): Extension<WorkspaceContext>,
+    Query(params): Query<V1TimelineEventsParams>,
+) -> impl IntoResponse {
+    let since = params.since.clone().unwrap_or_else(|| {
+        (Utc::now() - chrono::Duration::hours(24)).to_rfc3339()
+    });
+
+    match workspace
+        .workspace
+        .durable_store()
+        .list_timeline_events(&workspace.workspace_id, &since)
+        .await
+    {
+        Ok(events) => {
+            let limit = params.limit.unwrap_or(100);
+            let results: Vec<_> = events.into_iter().take(limit).collect();
+            Json(serde_json::json!({
+                "status": "ok",
+                "events": results,
+            }))
+        }
+        Err(e) => Json(serde_json::json!({
+            "status": "error",
+            "message": e.to_string(),
         })),
     }
 }

--- a/tests/sync_check_handler_cached_result.rs
+++ b/tests/sync_check_handler_cached_result.rs
@@ -156,6 +156,18 @@ impl MemoryStore for MockMemoryStore {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    async fn export(&self, _path: &std::path::Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn export_tree(&self, _workspace_id: &str, _path: &std::path::Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn import(&self, _path: &std::path::Path) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 fn make_session_record(seconds_ago: i64) -> MemoryRecord {
@@ -181,6 +193,9 @@ fn make_session_record(seconds_ago: i64) -> MemoryRecord {
         revision: 1,
         primary: true,
         parent_id: None,
+        cluster_id: None,
+        level: xavier::memory::schema::MemoryLevel::Raw,
+        relation: None,
         revisions: vec![],
     }
 }


### PR DESCRIPTION
This PR implements Phase 1 of the migration plan to use Xavier2 as the exclusive memory backend for Gestalt Rust. It includes schema alignments (chunk_id, importance mapping), new REST API endpoints required by Gestalt (recent memories, LLM context, timeline events), and integration into the Xavier CLI server. It also fixes several compilation issues in the unified agent lifecycle and memory adapters discovered during verification.

Fixes #149

---
*PR created automatically by Jules for task [9926054089238734546](https://jules.google.com/task/9926054089238734546) started by @iberi22*