### PR TITLE
Prompt cache awareness in proxy (system prompt dedup)

### DIFF
--- a/src/agents/provider.rs
+++ b/src/agents/provider.rs
@@ -463,25 +463,35 @@ impl ModelProviderClient {
     }
 
     pub async fn generate_text(&self, system_prompt: &str, user_prompt: &str) -> Result<String> {
+        self.generate_text_with_cache(system_prompt, user_prompt, false)
+            .await
+    }
+
+    pub async fn generate_text_with_cache(
+        &self,
+        system_prompt: &str,
+        user_prompt: &str,
+        use_cache: bool,
+    ) -> Result<String> {
         if !self.config.is_configured() || self.config.provider_mode == ProviderMode::Disabled {
             bail!("no LLM provider configured");
         }
 
         match self.config.target {
             ProviderTarget::GenericOpenAICompatible => {
-                self.generate_openai_compatible(system_prompt, user_prompt)
+                self.generate_openai_compatible(system_prompt, user_prompt, use_cache)
                     .await
             }
             ProviderTarget::AnthropicMessages => {
-                self.generate_anthropic_compatible(system_prompt, user_prompt)
+                self.generate_anthropic_compatible(system_prompt, user_prompt, use_cache)
                     .await
             }
             ProviderTarget::GeminiLegacy => {
-                self.generate_gemini_legacy(system_prompt, user_prompt)
+                self.generate_gemini_legacy(system_prompt, user_prompt, use_cache)
                     .await
             }
             ProviderTarget::MiniMaxLegacy => {
-                self.generate_minimax_legacy(system_prompt, user_prompt)
+                self.generate_minimax_legacy(system_prompt, user_prompt, use_cache)
                     .await
             }
         }
@@ -491,6 +501,7 @@ impl ModelProviderClient {
         &self,
         system_prompt: &str,
         user_prompt: &str,
+        use_cache: bool,
     ) -> Result<String> {
         let base_url = self
             .config
@@ -512,13 +523,24 @@ impl ModelProviderClient {
             request = request.bearer_auth(api_key);
         }
 
+        let mut messages = vec![
+            serde_json::json!({"role": "system", "content": system_prompt}),
+            serde_json::json!({"role": "user", "content": user_prompt}),
+        ];
+
+        // DeepSeek prompt cache support (OpenAI compatible)
+        if use_cache && self.config.provider_label == "deepseek" {
+            if let Some(msg) = messages.get_mut(0) {
+                if let Some(obj) = msg.as_object_mut() {
+                    obj.insert("cache_control".to_string(), serde_json::json!({"type": "ephemeral"}));
+                }
+            }
+        }
+
         let response = request
             .json(&serde_json::json!({
                 "model": self.config.model,
-                "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt}
-                ],
+                "messages": messages,
                 "temperature": 0.2,
                 "max_tokens": 500
             }))
@@ -544,6 +566,7 @@ impl ModelProviderClient {
         &self,
         system_prompt: &str,
         user_prompt: &str,
+        use_cache: bool,
     ) -> Result<String> {
         let base_url = self
             .config
@@ -557,14 +580,32 @@ impl ModelProviderClient {
             .context("missing Anthropic-compatible API key")?;
         let endpoint = anthropic_messages_endpoint(base_url);
 
+        let mut system_json = serde_json::json!([
+            {
+                "type": "text",
+                "text": system_prompt,
+            }
+        ]);
+
+        if use_cache {
+            if let Some(arr) = system_json.as_array_mut() {
+                if let Some(first) = arr.get_mut(0) {
+                    if let Some(obj) = first.as_object_mut() {
+                        obj.insert("cache_control".to_string(), serde_json::json!({"type": "ephemeral"}));
+                    }
+                }
+            }
+        }
+
         let response = self
             .client
             .post(endpoint)
             .header("x-api-key", api_key)
             .header("anthropic-version", "2023-06-01")
+            .header("anthropic-beta", "prompt-caching-2024-07-31")
             .json(&serde_json::json!({
                 "model": self.config.model,
-                "system": system_prompt,
+                "system": system_json,
                 "max_tokens": 500,
                 "temperature": 0.2,
                 "messages": [
@@ -593,6 +634,7 @@ impl ModelProviderClient {
         &self,
         system_prompt: &str,
         user_prompt: &str,
+        _use_cache: bool,
     ) -> Result<String> {
         let api_key = self
             .config
@@ -642,6 +684,7 @@ impl ModelProviderClient {
         &self,
         system_prompt: &str,
         user_prompt: &str,
+        _use_cache: bool,
     ) -> Result<String> {
         let api_key = self
             .config

--- a/src/agents/rate_limit.rs
+++ b/src/agents/rate_limit.rs
@@ -11,6 +11,7 @@ pub struct QuotaStatus {
     pub used_today: usize,
     pub used_weekly: usize,
     pub used_monthly: usize,
+    pub cache_hits: usize,
     pub rate_limited_until: Option<DateTime<Utc>>,
     pub last_update: DateTime<Utc>,
 }
@@ -32,10 +33,25 @@ impl RateLimitManager {
                 timestamp DATETIME DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
                 tokens_used INTEGER DEFAULT 0,
                 status_code INTEGER,
-                is_error BOOLEAN DEFAULT 0
+                is_error BOOLEAN DEFAULT 0,
+                cache_hits INTEGER DEFAULT 0
             )",
             [],
         )?;
+
+        // Migration: Add cache_hits column if missing
+        let mut stmt = conn.prepare("PRAGMA table_info(rate_limit_usage)")?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
+        let mut has_cache_hits = false;
+        for col in rows {
+            if col? == "cache_hits" {
+                has_cache_hits = true;
+                break;
+            }
+        }
+        if !has_cache_hits {
+            conn.execute("ALTER TABLE rate_limit_usage ADD COLUMN cache_hits INTEGER DEFAULT 0", [])?;
+        }
 
         conn.execute(
             "CREATE TABLE IF NOT EXISTS provider_quotas (
@@ -50,12 +66,12 @@ impl RateLimitManager {
         Ok(())
     }
 
-    pub async fn track_request(&self, provider: &str, tokens: usize, status: u16) -> Result<()> {
+    pub async fn track_request(&self, provider: &str, tokens: usize, status: u16, is_cache_hit: bool) -> Result<()> {
         let conn = self.db.lock();
         conn.execute(
-            "INSERT INTO rate_limit_usage (provider, tokens_used, status_code, is_error)
-             VALUES (?1, ?2, ?3, ?4)",
-            params![provider, tokens as i64, status, status >= 400],
+            "INSERT INTO rate_limit_usage (provider, tokens_used, status_code, is_error, cache_hits)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![provider, tokens as i64, status, status >= 400, if is_cache_hit { 1 } else { 0 }],
         )?;
 
         if status == 429 {
@@ -98,6 +114,12 @@ impl RateLimitManager {
             |row| row.get(0),
         )?;
 
+        let cache_hits: i64 = conn.query_row(
+            "SELECT COALESCE(SUM(cache_hits), 0) FROM rate_limit_usage WHERE provider = ?1",
+            params![provider],
+            |row| row.get(0),
+        )?;
+
         let rate_limited_until: Option<DateTime<Utc>> = conn.query_row(
             "SELECT rate_limited_until FROM provider_quotas WHERE provider = ?1",
             params![provider],
@@ -109,6 +131,7 @@ impl RateLimitManager {
             used_today: used_today as usize,
             used_weekly: used_weekly as usize,
             used_monthly: used_monthly as usize,
+            cache_hits: cache_hits as usize,
             rate_limited_until,
             last_update: now,
         })
@@ -134,6 +157,30 @@ impl RateLimitManager {
              ON CONFLICT(provider) DO UPDATE SET manual_limit_percentage = ?2, last_manual_update = ?3",
             params![provider, percentage, Utc::now()],
         )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use parking_lot::Mutex;
+
+    #[tokio::test]
+    async fn test_rate_limit_cache_hits() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        RateLimitManager::init_schema(&conn)?;
+        let manager = RateLimitManager::new(Arc::new(Mutex::new(conn)));
+
+        manager.track_request("test-provider", 100, 200, false).await?;
+        manager.track_request("test-provider", 100, 200, true).await?;
+        manager.track_request("test-provider", 100, 200, true).await?;
+
+        let status = manager.get_status("test-provider").await?;
+        assert_eq!(status.cache_hits, 2);
+        assert_eq!(status.used_today, 300);
+
         Ok(())
     }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -161,8 +161,8 @@ impl Cli {
                         let token = require_xavier_token()?;
                         let client = reqwest::Client::new();
                         let providers = ["opencode-go", "deepseek", "groq", "openai", "anthropic"];
-                        println!("{:<15} | {:<10} | {:<10} | {:<10} | {:<20}", "Provider", "Today", "Weekly", "Monthly", "Limited Until");
-                        println!("{:-<15}-+-{:-<10}-+-{:-<10}-+-{:-<10}-+-{:-<20}", "", "", "", "", "");
+                        println!("{:<15} | {:<10} | {:<10} | {:<10} | {:<10} | {:<20}", "Provider", "Today", "Weekly", "Monthly", "Cache Hits", "Limited Until");
+                        println!("{:-<15}-+-{:-<10}-+-{:-<10}-+-{:-<10}-+-{:-<10}-+-{:-<20}", "", "", "", "", "", "");
                         for p in providers {
                             let resp = client.get(format!("{}/v1/usage/status/{}", base_url, p))
                                 .header("X-Xavier-Token", &token)
@@ -170,8 +170,8 @@ impl Cli {
                             if resp.status().is_success() {
                                 let status: xavier::agents::rate_limit::QuotaStatus = resp.json().await?;
                                 let limited = status.rate_limited_until.map(|u| u.to_rfc3339()).unwrap_or_else(|| "No".to_string());
-                                println!("{:<15} | {:<10} | {:<10} | {:<10} | {:<20}", 
-                                    status.provider, status.used_today, status.used_weekly, status.used_monthly, limited);
+                                println!("{:<15} | {:<10} | {:<10} | {:<10} | {:<10} | {:<20}",
+                                    status.provider, status.used_today, status.used_weekly, status.used_monthly, status.cache_hits, limited);
                             }
                         }
                         Ok(())

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use crate::cli::state::CliState;
 use xavier::agents::provider::{ModelProviderClient, ModelProviderConfig};
 use tracing::{info, warn};
+use sha2::{Sha256, Digest};
 
 #[derive(Debug, Deserialize)]
 pub struct ProxyChatRequest {
@@ -20,6 +21,16 @@ pub async fn chat_proxy(
     State(state): State<CliState>,
     Json(req): Json<ProxyChatRequest>,
 ) -> Response {
+    // 0. Detect Prompt Cache
+    let system_msg = req.messages.iter()
+        .find(|m| m["role"] == "system")
+        .and_then(|m| m["content"].as_str())
+        .unwrap_or("You are a helpful assistant.");
+
+    let mut hasher = Sha256::new();
+    hasher.update(system_msg.as_bytes());
+    let system_hash = hex::encode(hasher.finalize());
+
     // 1. Resolve Provider based on Rate Limits
     // Order of priority as per AGENTS.md
     let providers = ["opencode-go", "deepseek", "groq", "openai", "anthropic"];
@@ -47,28 +58,40 @@ pub async fn chat_proxy(
 
     info!("Proxying request to provider: {}", provider_name);
 
+    let is_cache_hit = {
+        let mut cache = state.prompt_cache.lock();
+        let hashes = cache.entry(provider_name.clone()).or_insert_with(Vec::new);
+        let hit = hashes.contains(&system_hash);
+        if !hit {
+            hashes.push(system_hash);
+            if hashes.len() > 5 {
+                hashes.remove(0);
+            }
+        }
+        hit
+    };
+
+    if is_cache_hit {
+        info!("Prompt cache hit for provider {}", provider_name);
+    }
+
     // 2. Execute Request
     let config = ModelProviderConfig::for_provider(&provider_name).with_model_override(Some(req.model.clone()));
     let client = ModelProviderClient::new(config);
 
     // Extraction logic for Axum Proxy
-    let system_msg = req.messages.iter()
-        .find(|m| m["role"] == "system")
-        .and_then(|m| m["content"].as_str())
-        .unwrap_or("You are a helpful assistant.");
-    
     let user_msg = req.messages.iter()
         .filter(|m| m["role"] == "user")
         .last()
         .and_then(|m| m["content"].as_str())
         .unwrap_or("");
 
-    match client.generate_text(system_msg, user_msg).await {
+    match client.generate_text_with_cache(system_msg, user_msg, is_cache_hit).await {
         Ok(text) => {
             // 3. Track Usage
             // Rough token estimation (1 token ~= 4 chars)
             let tokens = (text.len() + user_msg.len()) / 4;
-            if let Err(e) = state.rate_manager.track_request(&provider_name, tokens, 200).await {
+            if let Err(e) = state.rate_manager.track_request(&provider_name, tokens, 200, is_cache_hit).await {
                 warn!("Failed to track request usage: {}", e);
             }
 
@@ -94,7 +117,7 @@ pub async fn chat_proxy(
         }
         Err(e) => {
             warn!("Provider {} failed: {}", provider_name, e);
-            if let Err(track_err) = state.rate_manager.track_request(&provider_name, 0, 500).await {
+            if let Err(track_err) = state.rate_manager.track_request(&provider_name, 0, 500, false).await {
                 warn!("Failed to track failed request: {}", track_err);
             }
             (StatusCode::INTERNAL_SERVER_ERROR, format!("Provider error: {}", e)).into_response()

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -208,6 +208,7 @@ pub async fn start_http_server(port: u16) -> Result<()> {
         event_bus,
         tasks,
         rate_manager: rate_manager.clone(),
+        prompt_cache: Arc::new(parking_lot::Mutex::new(HashMap::new())),
     };
 
     info!(

--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -12,8 +12,8 @@ use xavier::time::TimeMetricsStore;
 use xavier::agents::rate_limit::RateLimitManager;
 use xavier::coordination::{KeyLendingEngine, XavierEventBus};
 use xavier::tasks::store::{InMemoryTaskStore, TaskService};
-use xavier::AppState;
-use tokio::sync::RwLock;
+use parking_lot::Mutex;
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct CliState {
@@ -32,6 +32,7 @@ pub struct CliState {
     pub event_bus: XavierEventBus,
     pub tasks: Arc<TaskService<InMemoryTaskStore>>,
     pub rate_manager: Arc<RateLimitManager>,
+    pub prompt_cache: Arc<Mutex<HashMap<String, Vec<String>>>>,
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
Implemented prompt caching awareness in the Xavier chat proxy to optimize stable-prefix workflows.

Key changes:
- **Hashing & Deduplication**: System prompts are now hashed using SHA-256. A thread-safe cache in `CliState` stores the last 5 unique hashes per provider.
- **Provider Signaling**:
  - **Anthropic**: Added support for prompt caching by setting the `anthropic-beta` header and using content blocks with `cache_control: {"type": "ephemeral"}`.
  - **DeepSeek**: Injected `cache_control` markers into system messages for compatible endpoints.
- **Usage Tracking**: Added a `cache_hits` INTEGER column to the `rate_limit_usage` SQLite table. Includes a robust migration path using `PRAGMA table_info`.
- **CLI Updates**: The `xavier usage status` command now includes a "Cache Hits" column to monitor performance.
- **Backwards Compatibility**: Maintained compatibility by introducing `generate_text_with_cache` while keeping the standard `generate_text` signature unchanged for other callers.

Verified with `cargo check` and `cargo test` (including new coverage for rate tracking).

Fixes #285

---
*PR created automatically by Jules for task [1277509626530177041](https://jules.google.com/task/1277509626530177041) started by @iberi22*