### PR TITLE
TUI Quota Gauges for Provider Usage Visualization

### DIFF
--- a/src/main_tui.rs
+++ b/src/main_tui.rs
@@ -8,6 +8,7 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashMap,
     io,
     sync::Arc,
     time::{Duration, Instant},
@@ -58,6 +59,15 @@ impl XavierClient {
             .json::<serde_json::Value>()
             .await?;
 
+        let mut provider_quotas = HashMap::new();
+        if let Some(quotas) = resp["provider_quotas"].as_object() {
+            for (name, value) in quotas {
+                if let Ok(status) = serde_json::from_value::<xavier::agents::rate_limit::QuotaStatus>(value.clone()) {
+                    provider_quotas.insert(name.clone(), status);
+                }
+            }
+        }
+
         let metrics = DashboardMetrics {
             total_memories: resp["document_count"].as_u64().unwrap_or(0) as usize,
             total_beliefs: 0,
@@ -67,6 +77,7 @@ impl XavierClient {
             uptime_seconds: 0,
             storage_used: resp["storage_bytes_used"].as_u64().unwrap_or(0),
             storage_limit: resp["storage_bytes_limit"].as_u64().unwrap_or(0),
+            provider_quotas,
         };
         Ok(metrics)
     }
@@ -323,6 +334,9 @@ async fn main() -> Result<()> {
                         }
                         KeyCode::Char('/') if app.current_tab == 1 => {
                             app.input_mode = InputMode::Editing;
+                        }
+                        KeyCode::Char('u') => {
+                            app.on_tick().await;
                         }
                         _ => {}
                     },

--- a/src/ui/dashboard.rs
+++ b/src/ui/dashboard.rs
@@ -23,6 +23,7 @@ pub struct DashboardMetrics {
     pub uptime_seconds: u64,
     pub storage_used: u64,
     pub storage_limit: u64,
+    pub provider_quotas: HashMap<String, crate::agents::rate_limit::QuotaStatus>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -156,12 +157,33 @@ fn render_stats(f: &mut Frame, metrics: &DashboardMetrics, area: Rect) {
         Line::from("Keybindings:"),
         Line::from("  j/k: Scroll down/up"),
         Line::from("  Enter: View details"),
+        Line::from("  u: Refresh usage"),
         Line::from("  /: Search (Memory Explorer only)"),
     ];
     let p_help = Paragraph::new(help)
         .block(Block::default().borders(Borders::ALL).title("Help"))
         .style(Style::default().fg(Color::Gray));
     f.render_widget(p_help, horizontal_chunks[1]);
+
+    let mut quota_constraints = Vec::new();
+    if metrics.storage_limit > 0 {
+        quota_constraints.push(Constraint::Length(3));
+    }
+
+    let mut providers: Vec<_> = metrics.provider_quotas.keys().collect();
+    providers.sort();
+
+    for _ in &providers {
+        quota_constraints.push(Constraint::Length(3));
+    }
+    quota_constraints.push(Constraint::Min(0));
+
+    let quota_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(quota_constraints)
+        .split(vertical_chunks[1]);
+
+    let mut current_idx = 0;
 
     if metrics.storage_limit > 0 {
         let ratio = metrics.storage_used as f64 / metrics.storage_limit as f64;
@@ -181,7 +203,37 @@ fn render_stats(f: &mut Frame, metrics: &DashboardMetrics, area: Rect) {
             )
             .ratio(ratio.min(1.0))
             .label(label);
-        f.render_widget(gauge, vertical_chunks[1]);
+        f.render_widget(gauge, quota_chunks[current_idx]);
+        current_idx += 1;
+    }
+
+    for name in providers {
+        let status = &metrics.provider_quotas[name];
+        // TODO: Move limit to QuotaStatus in src/agents/rate_limit.rs
+        let limit = 10000.0;
+        let ratio = (status.used_today as f64 / limit).min(1.0);
+
+        let color = if ratio < 0.7 {
+            Color::Green
+        } else if ratio < 0.9 {
+            Color::Yellow
+        } else {
+            Color::Red
+        };
+
+        let label = format!(
+            "Usage: {:.2}% ({}/10k tokens)",
+            ratio * 100.0,
+            status.used_today
+        );
+
+        let gauge = Gauge::default()
+            .block(Block::default().borders(Borders::ALL).title(format!("Provider: {}", name)))
+            .gauge_style(Style::default().fg(color).bg(Color::Black))
+            .ratio(ratio)
+            .label(label);
+        f.render_widget(gauge, quota_chunks[current_idx]);
+        current_idx += 1;
     }
 }
 


### PR DESCRIPTION
Implemented real-time provider quota visualization in the Xavier TUI dashboard. 

Key changes:
1. **Dashboard Metrics Update**: The `DashboardMetrics` struct now includes a `provider_quotas` field, mapping provider names to their `QuotaStatus`.
2. **Dynamic UI Rendering**: The `render_stats` function in `src/ui/dashboard.rs` was refactored to dynamically allocate space for multiple gauges. It now renders a gauge for storage usage followed by individual gauges for each active provider (sorted alphabetically).
3. **Color-Coding**: Usage ratios are visualized with colors: Green for under 70%, Yellow for 70-90%, and Red for over 90% (capped at 100%).
4. **API Integration**: The TUI client in `src/main_tui.rs` was updated to extract and deserialize `provider_quotas` from the `/v1/account/usage` response.
5. **Interactive Refresh**: A new 'u' keybinding allows users to manually trigger a metrics refresh from the dashboard tab.

The implementation uses a placeholder limit of 10,000 tokens for provider ratio calculations, as the current `QuotaStatus` domain model does not yet expose per-provider limits. A TODO and clear labeling have been added to facilitate future enhancement of the rate limit system.

Fixes #286

---
*PR created automatically by Jules for task [1365032087696096985](https://jules.google.com/task/1365032087696096985) started by @iberi22*