### PR TITLE
Share reqwest::Client instance across CLI and server

### DIFF
--- a/src/a2a/mod.rs
+++ b/src/a2a/mod.rs
@@ -200,9 +200,9 @@ pub struct A2AClient {
 
 impl A2AClient {
     /// Creates a client with an empty in-memory discovery registry.
-    pub fn new() -> Self {
+    pub fn new(http_client: reqwest::Client) -> Self {
         Self {
-            http_client: reqwest::Client::new(),
+            http_client,
             agent_cards: RwLock::new(HashMap::new()),
         }
     }
@@ -360,7 +360,7 @@ impl A2AClient {
 
 impl Default for A2AClient {
     fn default() -> Self {
-        Self::new()
+        Self::new(crate::utils::http::DEFAULT_HTTP_CLIENT.clone())
     }
 }
 
@@ -751,7 +751,7 @@ mod tests {
 
     #[test]
     fn client_registry_returns_registered_agent() {
-        let client = A2AClient::new();
+        let client = A2AClient::new(crate::utils::http::DEFAULT_HTTP_CLIENT.clone());
         let card = create_xavier_agent_card();
         client.register_agent("xavier", card.clone());
 

--- a/src/adapters/inbound/http/routes.rs
+++ b/src/adapters/inbound/http/routes.rs
@@ -18,6 +18,16 @@ use crate::session::types::SessionEvent;
 use crate::settings::XavierSettings;
 use crate::tasks::session_sync_task::get_last_sync_result;
 use crate::verification::auto_verifier::AutoVerifier;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+pub static LIB_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent(concat!("xavier-lib/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .expect("failed to build library HTTP client")
+});
 
 // ─── Module-level TimeMetricsPort (initialized by CLI) ────────────────────────
 static TIME_STORE: std::sync::OnceLock<Arc<dyn TimeMetricsPort>> = std::sync::OnceLock::new();
@@ -150,7 +160,7 @@ pub async fn verify_save_handler(
         }
     };
 
-    let client = reqwest::Client::new();
+    let client = LIB_HTTP_CLIENT.clone();
     let result = AutoVerifier::verify_save(
         &client,
         &xavier_url,

--- a/src/adapters/outbound/http_health_adapter.rs
+++ b/src/adapters/outbound/http_health_adapter.rs
@@ -9,11 +9,7 @@ pub struct HttpHealthAdapter {
 }
 
 impl HttpHealthAdapter {
-    pub fn new(base_url: String) -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(5))
-            .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
+    pub fn new(base_url: String, client: reqwest::Client) -> Self {
         Self { base_url, client }
     }
 }

--- a/src/agents/ui_render.rs
+++ b/src/agents/ui_render.rs
@@ -216,6 +216,7 @@ mod tests {
                     path: "memory/doc-1".to_string(),
                     content: "Relevant memory".to_string(),
                     relevance_score: 1.0,
+                    token_count: 2,
                     metadata: serde_json::json!({}),
                 }],
                 search_type: SearchType::Hybrid,

--- a/src/app/verification_service.rs
+++ b/src/app/verification_service.rs
@@ -7,16 +7,14 @@ pub struct VerificationService {
 }
 
 impl VerificationService {
-    pub fn new() -> Self {
-        Self {
-            client: reqwest::Client::new(),
-        }
+    pub fn new(client: reqwest::Client) -> Self {
+        Self { client }
     }
 }
 
 impl Default for VerificationService {
     fn default() -> Self {
-        Self::new()
+        Self::new(crate::utils::http::DEFAULT_HTTP_CLIENT.clone())
     }
 }
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -9,9 +9,17 @@ use crate::cli::state::Cli;
 use anyhow::{anyhow, Result};
 use clap::Subcommand;
 
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc, sync::LazyLock, time::Duration};
 
 use tokio::sync::RwLock;
+
+pub static CLI_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent(concat!("xavier-cli/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .expect("failed to build HTTP client")
+});
 
 use xavier::adapters::inbound::http::routes::{
     sync_check_handler, time_metric_handler, verify_save_handler,
@@ -206,7 +214,7 @@ impl Cli {
                 match cmd {
                     UsageCommand::Status => {
                         let token = require_xavier_token()?;
-                        let client = reqwest::Client::new();
+                        let client = CLI_HTTP_CLIENT.clone();
                         let providers = ["opencode-go", "deepseek", "groq", "openai", "anthropic"];
                         println!(
                             "{:<15} | {:<10} | {:<10} | {:<10} | {:<10} | {:<20}",
@@ -247,7 +255,7 @@ impl Cli {
                         percentage,
                     } => {
                         let token = require_xavier_token()?;
-                        let client = reqwest::Client::new();
+                        let client = CLI_HTTP_CLIENT.clone();
                         let resp = client.post(format!("{}/v1/usage/update", base_url))
                             .header("X-Xavier-Token", &token)
                             .json(&serde_json::json!({ "provider": provider, "percentage": percentage }))
@@ -261,7 +269,7 @@ impl Cli {
                     }
                     UsageCommand::Cooldown { provider, minutes } => {
                         let token = require_xavier_token()?;
-                        let client = reqwest::Client::new();
+                        let client = CLI_HTTP_CLIENT.clone();
                         let resp = client
                             .post(format!("{}/v1/usage/cooldown", base_url))
                             .header("X-Xavier-Token", &token)
@@ -348,7 +356,7 @@ pub async fn session_load(ctx: &str) -> Result<String> {
     let token = require_xavier_token()?;
     let url = format!("{}/memory/search", resolve_base_url());
 
-    let client = reqwest::Client::new();
+    let client = CLI_HTTP_CLIENT.clone();
     let response = client
         .get(&url)
         .header("X-Xavier-Token", &token)
@@ -410,7 +418,7 @@ pub async fn add_memory(content: &str, title: Option<&str>, kind: Option<&str>) 
         body["metadata"]["kind"] = serde_json::json!(k);
     }
 
-    let client = reqwest::Client::new();
+    let client = CLI_HTTP_CLIENT.clone();
     let response = client
         .post(&url)
         .header("X-Xavier-Token", &token)
@@ -447,7 +455,7 @@ pub async fn recall_memories(query: &str, limit: usize) -> Result<()> {
         "include_scores": true,
     });
 
-    let client = reqwest::Client::new();
+    let client = CLI_HTTP_CLIENT.clone();
     let response = client
         .post(&url)
         .header("X-Xavier-Token", &token)
@@ -493,7 +501,7 @@ pub async fn show_stats() -> Result<()> {
     let base_url = resolve_base_url();
     let url = format!("{}/memory/stats", base_url);
 
-    let client = reqwest::Client::new();
+    let client = CLI_HTTP_CLIENT.clone();
     let response = client
         .get(&url)
         .header("X-Xavier-Token", &token)
@@ -523,7 +531,7 @@ pub async fn show_stats() -> Result<()> {
 async fn handle_code_command(cmd: CodeCommand) -> Result<()> {
     let token = require_xavier_token()?;
     let base_url = resolve_base_url();
-    let client = reqwest::Client::new();
+    let client = CLI_HTTP_CLIENT.clone();
 
     let response = match cmd {
         CodeCommand::Scan { path } => {
@@ -643,7 +651,7 @@ pub async fn session_save(session_id: &str, content: &str) -> Result<()> {
         }
     });
 
-    let client = reqwest::Client::new();
+    let client = CLI_HTTP_CLIENT.clone();
     let response = client
         .post(&url)
         .header("X-Xavier-Token", &token)
@@ -943,7 +951,7 @@ async fn handle_secrets_command(cmd: SecretsCommand) -> Result<()> {
 async fn lend_secret(name: &str, agent: &str, ttl: u64) -> Result<()> {
     let token = xavier_token();
     let url = format!("{}/secrets/lend", resolve_base_url());
-    let client = reqwest::Client::new();
+    let client = CLI_HTTP_CLIENT.clone();
 
     let response = client
         .post(&url)
@@ -970,7 +978,7 @@ async fn lend_secret(name: &str, agent: &str, ttl: u64) -> Result<()> {
 async fn list_leases() -> Result<()> {
     let token = xavier_token();
     let url = format!("{}/secrets/leases", resolve_base_url());
-    let client = reqwest::Client::new();
+    let client = CLI_HTTP_CLIENT.clone();
 
     let response = client
         .get(&url)
@@ -1006,7 +1014,7 @@ async fn list_leases() -> Result<()> {
 async fn revoke_lease(token_str: &str) -> Result<()> {
     let token = xavier_token();
     let url = format!("{}/secrets/revoke", resolve_base_url());
-    let client = reqwest::Client::new();
+    let client = CLI_HTTP_CLIENT.clone();
 
     let response = client
         .post(&url)
@@ -1026,7 +1034,7 @@ async fn revoke_lease(token_str: &str) -> Result<()> {
 async fn check_lease_status(token_str: &str) -> Result<()> {
     let token = xavier_token();
     let url = format!("{}/secrets/status/{}", resolve_base_url(), token_str);
-    let client = reqwest::Client::new();
+    let client = CLI_HTTP_CLIENT.clone();
 
     let response = client
         .get(&url)

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -109,11 +109,19 @@ pub async fn start_http_server(port: u16) -> Result<()> {
             info!("TimeMetricsStore schema init warning: {}", e);
         }
     }
+    let http_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent(concat!("xavier-server/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| anyhow!("Failed to build HTTP client: {}", e))?;
+
     // Register global time metrics port for HTTP handler (wrap in adapter)
     use xavier::adapters::inbound::http::routes::{init_health_port, init_time_store};
     use xavier::adapters::inbound::http::time_metrics_adapter::TimeMetricsAdapter;
-    let health_adapter = Arc::new(HttpHealthAdapter::new(resolve_base_url_for_port(port)))
-        as Arc<dyn HealthCheckPort>;
+    let health_adapter = Arc::new(HttpHealthAdapter::new(
+        resolve_base_url_for_port(port),
+        http_client.clone(),
+    )) as Arc<dyn HealthCheckPort>;
     let time_adapter =
         Arc::new(TimeMetricsAdapter::new(Arc::clone(&time_store))) as Arc<dyn TimeMetricsPort>;
     init_time_store(time_adapter);
@@ -216,6 +224,7 @@ pub async fn start_http_server(port: u16) -> Result<()> {
         tasks,
         rate_manager: rate_manager.clone(),
         prompt_cache: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+        http_client,
     };
 
     info!(
@@ -1789,7 +1798,7 @@ pub async fn search_memories(query: &str, limit: usize) -> Result<()> {
     let base_url = resolve_base_url();
     let url = format!("{}/memory/search", base_url);
 
-    let client = reqwest::Client::new();
+    let client = crate::cli::commands::CLI_HTTP_CLIENT.clone();
     let response = client
         .post(&url)
         .header("X-Xavier-Token", &token)

--- a/src/cli/state.rs
+++ b/src/cli/state.rs
@@ -35,6 +35,7 @@ pub struct CliState {
     pub tasks: Arc<TaskService<InMemoryTaskStore>>,
     pub rate_manager: Arc<RateLimitManager>,
     pub prompt_cache: Arc<Mutex<HashMap<String, Vec<String>>>>,
+    pub http_client: reqwest::Client,
 }
 
 #[derive(Parser)]

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -48,6 +48,8 @@ mod tests {
                 "async fn search_memories(query: &str, limit: usize) -> Result<()>".to_string(),
             ),
             parent: None,
+            stable_id: None,
+            complexity: Some(0.0),
         })
         .unwrap();
         db.insert_symbol(&Symbol {
@@ -64,6 +66,8 @@ mod tests {
                 "async fn add_memory(content: &str, title: Option<&str>, kind: Option<&str>) -> Result<()>".to_string(),
             ),
             parent: None,
+            stable_id: None,
+            complexity: Some(0.0),
         })
         .unwrap();
 

--- a/src/tasks/session_sync_task.rs
+++ b/src/tasks/session_sync_task.rs
@@ -522,7 +522,13 @@ impl Default for SessionSyncTask {
                     }
                 };
 
-                crate::adapters::outbound::http_health_adapter::HttpHealthAdapter::new(final_url)
+                let client = reqwest::Client::builder()
+                    .timeout(Duration::from_secs(30))
+                    .user_agent(concat!("xavier-sync-task/", env!("CARGO_PKG_VERSION")))
+                    .build()
+                    .expect("failed to build sync task HTTP client");
+
+                crate::adapters::outbound::http_health_adapter::HttpHealthAdapter::new(final_url, client)
             }),
             memory_store: None,
             last_check: Arc::new(TokioRwLock::new(Instant::now())),

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -1,0 +1,10 @@
+use std::sync::LazyLock;
+use std::time::Duration;
+
+pub static DEFAULT_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent(concat!("xavier-internal/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .expect("failed to build default HTTP client")
+});

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,3 +5,4 @@
 pub mod connection_pool;
 pub mod crypto;
 pub mod file_traversal;
+pub mod http;


### PR DESCRIPTION
This change refactors Xavier to reuse `reqwest::Client` instances across the codebase, adhering to the hexagonal architecture rules and improving performance.

Key changes:
- Created `CLI_HTTP_CLIENT` in `src/cli/commands.rs` using `std::sync::LazyLock`.
- Created `LIB_HTTP_CLIENT` in `src/adapters/inbound/http/routes.rs` for shared use in library handlers.
- Created `DEFAULT_HTTP_CLIENT` in `src/utils/http.rs` to serve as a shared instance for `Default` implementations.
- Modified `CliState` to include and share an `http_client` instance initialized during server startup.
- Updated all identified call sites (15+) to use these shared instances instead of `reqwest::Client::new()`.
- Ensured all shared clients use a minimum 30-second timeout and a descriptive User-Agent.
- Refactored core services (`A2AClient`, `VerificationService`, `HttpHealthAdapter`) to support dependency injection of the HTTP client.
- Fixed schema-related compilation errors in `src/cli/tests.rs` and `src/agents/ui_render.rs` encountered during verification.

These optimizations prevent OS socket descriptor exhaustion and improve latency by enabling TCP connection reuse.

Fixes #300

---
*PR created automatically by Jules for task [7103340393686327466](https://jules.google.com/task/7103340393686327466) started by @iberi22*