### PR TITLE
Implement Fixed Entity & Relationship Layer for Belief Graph

### DIFF
--- a/src/agents/extraction.rs
+++ b/src/agents/extraction.rs
@@ -1,0 +1,155 @@
+//! Extraction pipeline for the Belief Graph.
+//!
+//! Provides services for extracting structured entities and relationships
+//! from unstructured text while enforcing a strict schema.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::domain::memory::graph::{
+    GraphEntity, GraphEntityType, GraphRelationship, GraphRelationshipType,
+};
+use crate::memory::graph_store::GraphStore;
+
+/// Structured output for entity extraction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedEntity {
+    pub name: String,
+    pub entity_type: GraphEntityType,
+    pub description: Option<String>,
+}
+
+/// Structured output for relationship extraction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedRelationship {
+    pub source_name: String,
+    pub target_name: String,
+    pub relation_type: GraphRelationshipType,
+}
+
+/// Result of the extraction process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractionResult {
+    pub entities: Vec<ExtractedEntity>,
+    pub relationships: Vec<ExtractedRelationship>,
+}
+
+pub struct ExtractionService {
+    graph_store: Arc<GraphStore>,
+}
+
+impl ExtractionService {
+    pub fn new(graph_store: Arc<GraphStore>) -> Self {
+        Self { graph_store }
+    }
+
+    /// Extracts entities and relationships from text and persists them.
+    pub async fn process_text(&self, text: &str) -> Result<ExtractionResult> {
+        // In a real implementation, this would call an LLM with a constrained JSON schema.
+        // For this foundation, we implement a deterministic rule-based extractor
+        // that can be later augmented with LLM calls.
+
+        let extracted = self.extract_deterministic(text);
+
+        // Persist extracted data
+        for ent in &extracted.entities {
+            let entity = GraphEntity::new(ent.name.clone(), ent.entity_type);
+            self.graph_store.upsert_entity(entity)?;
+        }
+
+        for rel in &extracted.relationships {
+            let source_id = self.resolve_entity_id(&rel.source_name, None)?;
+            let target_id = self.resolve_entity_id(&rel.target_name, None)?;
+
+            if let (Some(s_id), Some(t_id)) = (source_id, target_id) {
+                let relationship = GraphRelationship::new(s_id, t_id, rel.relation_type);
+                self.graph_store.upsert_relationship(relationship)?;
+            }
+        }
+
+        Ok(extracted)
+    }
+
+    fn extract_deterministic(&self, text: &str) -> ExtractionResult {
+        // Simple deterministic extraction logic for testing and baseline
+        let mut entities = Vec::new();
+        let mut relationships = Vec::new();
+
+        // Very basic "X works at Y" pattern
+        if text.contains(" works at ") {
+            let parts: Vec<&str> = text.split(" works at ").collect();
+            if parts.len() == 2 {
+                let person_name = parts[0].trim();
+                let org_name = parts[1].trim().trim_matches('.');
+
+                entities.push(ExtractedEntity {
+                    name: person_name.to_string(),
+                    entity_type: GraphEntityType::Person,
+                    description: None,
+                });
+
+                entities.push(ExtractedEntity {
+                    name: org_name.to_string(),
+                    entity_type: GraphEntityType::Organization,
+                    description: None,
+                });
+
+                relationships.push(ExtractedRelationship {
+                    source_name: person_name.to_string(),
+                    target_name: org_name.to_string(),
+                    relation_type: GraphRelationshipType::WorksAt,
+                });
+            }
+        }
+
+        ExtractionResult {
+            entities,
+            relationships,
+        }
+    }
+
+    fn resolve_entity_id(&self, name: &str, entity_type: Option<GraphEntityType>) -> Result<Option<String>> {
+        let normalized = GraphEntity::normalize(name);
+        let entities = self.graph_store.list_entities()?;
+
+        let found = entities.iter().find(|e| {
+            if let Some(et) = entity_type {
+                e.normalized_name == normalized && e.entity_type == et
+            } else {
+                e.normalized_name == normalized
+            }
+        });
+
+        Ok(found.map(|e| e.id.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex;
+    use rusqlite::Connection;
+
+    #[tokio::test]
+    async fn test_process_text_extraction() {
+        let conn = Arc::new(Mutex::new(Connection::open_in_memory().unwrap()));
+        let graph_store = Arc::new(GraphStore::new(conn).unwrap());
+        let service = ExtractionService::new(graph_store.clone());
+
+        let text = "Alice works at Acme Corp.";
+        let result = service.process_text(text).await.unwrap();
+
+        assert_eq!(result.entities.len(), 2);
+        assert_eq!(result.relationships.len(), 1);
+
+        let entities = graph_store.list_entities().unwrap();
+        assert_eq!(entities.len(), 2);
+
+        let alice = entities.iter().find(|e| e.name == "Alice").unwrap();
+        assert_eq!(alice.entity_type, GraphEntityType::Person);
+
+        let acme = entities.iter().find(|e| e.name == "Acme Corp").unwrap();
+        assert_eq!(acme.entity_type, GraphEntityType::Organization);
+    }
+}

--- a/src/agents/mod.rs
+++ b/src/agents/mod.rs
@@ -1,4 +1,5 @@
 pub mod curation;
+pub mod extraction;
 pub mod provider;
 pub mod rate_limit;
 pub mod router;

--- a/src/domain/memory/graph.rs
+++ b/src/domain/memory/graph.rs
@@ -1,0 +1,203 @@
+//! Domain models for Xavier's Belief Graph.
+//!
+//! Provides strict schema definitions for Entities and Relationships
+//! to ensure determinism and prevent entity drift.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Strict entity types for the Belief Graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphEntityType {
+    Person,
+    Organization,
+    Location,
+    Product,
+    Concept,
+    Event,
+    TechnicalTerm,
+    Tool,
+}
+
+impl GraphEntityType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Person => "person",
+            Self::Organization => "organization",
+            Self::Location => "location",
+            Self::Product => "product",
+            Self::Concept => "concept",
+            Self::Event => "event",
+            Self::TechnicalTerm => "technical_term",
+            Self::Tool => "tool",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "person" => Some(Self::Person),
+            "organization" | "org" => Some(Self::Organization),
+            "location" => Some(Self::Location),
+            "product" => Some(Self::Product),
+            "concept" => Some(Self::Concept),
+            "event" => Some(Self::Event),
+            "technical_term" | "tech_term" => Some(Self::TechnicalTerm),
+            "tool" => Some(Self::Tool),
+            _ => None,
+        }
+    }
+}
+
+/// Strict relationship types for the Belief Graph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphRelationshipType {
+    WorksAt,
+    LocatedIn,
+    PartOf,
+    IsA,
+    Uses,
+    CreatedBy,
+    RelatedTo,
+    CollaboratesWith,
+    MemberOf,
+    AcquiredBy,
+    Supports,
+    CompetesWith,
+}
+
+impl GraphRelationshipType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::WorksAt => "works_at",
+            Self::LocatedIn => "located_in",
+            Self::PartOf => "part_of",
+            Self::IsA => "is_a",
+            Self::Uses => "uses",
+            Self::CreatedBy => "created_by",
+            Self::RelatedTo => "related_to",
+            Self::CollaboratesWith => "collaborates_with",
+            Self::MemberOf => "member_of",
+            Self::AcquiredBy => "acquired_by",
+            Self::Supports => "supports",
+            Self::CompetesWith => "competes_with",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "works_at" => Some(Self::WorksAt),
+            "located_in" => Some(Self::LocatedIn),
+            "part_of" => Some(Self::PartOf),
+            "is_a" => Some(Self::IsA),
+            "uses" => Some(Self::Uses),
+            "created_by" => Some(Self::CreatedBy),
+            "related_to" => Some(Self::RelatedTo),
+            "collaborates_with" => Some(Self::CollaboratesWith),
+            "member_of" => Some(Self::MemberOf),
+            "acquired_by" => Some(Self::AcquiredBy),
+            "supports" => Some(Self::Supports),
+            "competes_with" => Some(Self::CompetesWith),
+            _ => None,
+        }
+    }
+}
+
+/// A node in the Belief Graph representing a resolved entity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphEntity {
+    pub id: String,
+    pub name: String,
+    pub normalized_name: String,
+    pub entity_type: GraphEntityType,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub description: Option<String>,
+    pub trust_score: f32,
+    pub confirmation_count: u32,
+    pub metadata: HashMap<String, serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl GraphEntity {
+    pub fn new(name: String, entity_type: GraphEntityType) -> Self {
+        let now = Utc::now();
+        let normalized_name = Self::normalize(&name);
+        Self {
+            id: ulid::Ulid::new().to_string(),
+            name,
+            normalized_name,
+            entity_type,
+            aliases: Vec::new(),
+            description: None,
+            trust_score: 0.5,
+            confirmation_count: 1,
+            metadata: HashMap::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn normalize(name: &str) -> String {
+        name.trim().to_lowercase()
+    }
+
+    pub fn add_alias(&mut self, alias: String) {
+        let normalized = Self::normalize(&alias);
+        if normalized != self.normalized_name && !self.aliases.contains(&normalized) {
+            self.aliases.push(normalized);
+            self.updated_at = Utc::now();
+        }
+    }
+
+    pub fn confirm(&mut self) {
+        self.confirmation_count += 1;
+        // Simple trust score update: 0.5 -> 0.7 -> 0.83 -> 0.9 -> ...
+        self.trust_score = (self.trust_score + 0.2 * (1.0 - self.trust_score)).min(1.0);
+        self.updated_at = Utc::now();
+    }
+}
+
+/// An edge in the Belief Graph representing a directed relationship between entities.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphRelationship {
+    pub id: String,
+    pub source_id: String,
+    pub target_id: String,
+    pub relation_type: GraphRelationshipType,
+    pub weight: f32,
+    pub confirmation_count: u32,
+    pub metadata: HashMap<String, serde_json::Value>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl GraphRelationship {
+    pub fn new(
+        source_id: String,
+        target_id: String,
+        relation_type: GraphRelationshipType,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: ulid::Ulid::new().to_string(),
+            source_id,
+            target_id,
+            relation_type,
+            weight: 0.5,
+            confirmation_count: 1,
+            metadata: HashMap::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    pub fn confirm(&mut self) {
+        self.confirmation_count += 1;
+        self.weight = (self.weight + 0.2 * (1.0 - self.weight)).min(1.0);
+        self.updated_at = Utc::now();
+    }
+}

--- a/src/domain/memory/mod.rs
+++ b/src/domain/memory/mod.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 pub use crate::memory::schema::MemoryQueryFilters;
 pub use crate::memory::store::MemoryRecord;
 
+pub mod graph;
+
 /// Core TimeMetric domain value — NOT a DTO.
 /// Used by the TimeMetrics inbound port to decouple from HTTP DTOs.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/memory/graph_store.rs
+++ b/src/memory/graph_store.rs
@@ -1,0 +1,262 @@
+//! SQLite storage implementation for Xavier's Belief Graph.
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use parking_lot::Mutex;
+use rusqlite::{params, Connection};
+use std::sync::Arc;
+
+use crate::domain::memory::graph::{GraphEntity, GraphEntityType, GraphRelationship};
+
+pub const TABLE_GRAPH_NODES: &str = "graph_nodes";
+pub const TABLE_GRAPH_EDGES: &str = "graph_edges";
+
+pub struct GraphStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl GraphStore {
+    pub fn new(conn: Arc<Mutex<Connection>>) -> Result<Self> {
+        let store = Self { conn };
+        store.init_schema()?;
+        Ok(store)
+    }
+
+    fn init_schema(&self) -> Result<()> {
+        let conn = self.conn.lock();
+        conn.execute_batch(&format!(
+            r#"
+            CREATE TABLE IF NOT EXISTS {} (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                normalized_name TEXT NOT NULL,
+                entity_type TEXT NOT NULL,
+                aliases TEXT NOT NULL DEFAULT '[]',
+                description TEXT,
+                trust_score REAL NOT NULL DEFAULT 0.5,
+                confirmation_count INTEGER NOT NULL DEFAULT 1,
+                metadata TEXT NOT NULL DEFAULT '{{}}',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS {} (
+                id TEXT PRIMARY KEY,
+                source_id TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                relation_type TEXT NOT NULL,
+                weight REAL NOT NULL DEFAULT 0.5,
+                confirmation_count INTEGER NOT NULL DEFAULT 1,
+                metadata TEXT NOT NULL DEFAULT '{{}}',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                FOREIGN KEY (source_id) REFERENCES {}(id) ON DELETE CASCADE,
+                FOREIGN KEY (target_id) REFERENCES {}(id) ON DELETE CASCADE
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_graph_nodes_normalized ON {}(normalized_name);
+            CREATE INDEX IF NOT EXISTS idx_graph_edges_source ON {}(source_id);
+            CREATE INDEX IF NOT EXISTS idx_graph_edges_target ON {}(target_id);
+            "#,
+            TABLE_GRAPH_NODES,
+            TABLE_GRAPH_EDGES,
+            TABLE_GRAPH_NODES,
+            TABLE_GRAPH_NODES,
+            TABLE_GRAPH_NODES,
+            TABLE_GRAPH_EDGES,
+            TABLE_GRAPH_EDGES
+        ))?;
+        Ok(())
+    }
+
+    pub fn upsert_entity(&self, entity: GraphEntity) -> Result<String> {
+        let conn = self.conn.lock();
+
+        // Deduplication logic: check by normalized_name and entity_type
+        let mut stmt = conn.prepare(&format!(
+            "SELECT id FROM {} WHERE normalized_name = ?1 AND entity_type = ?2",
+            TABLE_GRAPH_NODES
+        ))?;
+
+        let existing_id: Option<String> = stmt.query_row(
+            params![entity.normalized_name, entity.entity_type.as_str()],
+            |row| row.get(0)
+        ).ok();
+
+        if let Some(id) = existing_id {
+            // Update existing entity
+            conn.execute(
+                &format!(
+                    "UPDATE {} SET confirmation_count = confirmation_count + 1, trust_score = MIN(1.0, trust_score + 0.1), updated_at = ?2 WHERE id = ?1",
+                    TABLE_GRAPH_NODES
+                ),
+                params![id, Utc::now().to_rfc3339()],
+            )?;
+            Ok(id)
+        } else {
+            // Insert new entity
+            conn.execute(
+                &format!(
+                    "INSERT INTO {} (id, name, normalized_name, entity_type, aliases, description, trust_score, confirmation_count, metadata, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                    TABLE_GRAPH_NODES
+                ),
+                params![
+                    entity.id,
+                    entity.name,
+                    entity.normalized_name,
+                    entity.entity_type.as_str(),
+                    serde_json::to_string(&entity.aliases)?,
+                    entity.description,
+                    entity.trust_score,
+                    entity.confirmation_count,
+                    serde_json::to_string(&entity.metadata)?,
+                    entity.created_at.to_rfc3339(),
+                    entity.updated_at.to_rfc3339(),
+                ],
+            )?;
+            Ok(entity.id)
+        }
+    }
+
+    pub fn upsert_relationship(&self, rel: GraphRelationship) -> Result<String> {
+        let conn = self.conn.lock();
+
+        // Check if relationship already exists
+        let mut stmt = conn.prepare(&format!(
+            "SELECT id FROM {} WHERE source_id = ?1 AND target_id = ?2 AND relation_type = ?3",
+            TABLE_GRAPH_EDGES
+        ))?;
+
+        let existing_id: Option<String> = stmt.query_row(
+            params![rel.source_id, rel.target_id, rel.relation_type.as_str()],
+            |row| row.get(0)
+        ).ok();
+
+        if let Some(id) = existing_id {
+            // Update existing relationship
+            conn.execute(
+                &format!(
+                    "UPDATE {} SET confirmation_count = confirmation_count + 1, weight = MIN(1.0, weight + 0.1), updated_at = ?2 WHERE id = ?1",
+                    TABLE_GRAPH_EDGES
+                ),
+                params![id, Utc::now().to_rfc3339()],
+            )?;
+            Ok(id)
+        } else {
+            // Insert new relationship
+            conn.execute(
+                &format!(
+                    "INSERT INTO {} (id, source_id, target_id, relation_type, weight, confirmation_count, metadata, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                    TABLE_GRAPH_EDGES
+                ),
+                params![
+                    rel.id,
+                    rel.source_id,
+                    rel.target_id,
+                    rel.relation_type.as_str(),
+                    rel.weight,
+                    rel.confirmation_count,
+                    serde_json::to_string(&rel.metadata)?,
+                    rel.created_at.to_rfc3339(),
+                    rel.updated_at.to_rfc3339(),
+                ],
+            )?;
+            Ok(rel.id)
+        }
+    }
+
+    pub fn get_entity(&self, id: &str) -> Result<Option<GraphEntity>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(&format!(
+            "SELECT id, name, normalized_name, entity_type, aliases, description, trust_score, confirmation_count, metadata, created_at, updated_at FROM {} WHERE id = ?",
+            TABLE_GRAPH_NODES
+        ))?;
+
+        let entity = stmt.query_row([id], |row| {
+            let entity_type_str: String = row.get(3)?;
+            let aliases_str: String = row.get(4)?;
+            let metadata_str: String = row.get(8)?;
+
+            Ok(GraphEntity {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                normalized_name: row.get(2)?,
+                entity_type: GraphEntityType::parse(&entity_type_str).unwrap_or(GraphEntityType::Concept),
+                aliases: serde_json::from_str(&aliases_str).unwrap_or_default(),
+                description: row.get(5)?,
+                trust_score: row.get(6)?,
+                confirmation_count: row.get(7)?,
+                metadata: serde_json::from_str(&metadata_str).unwrap_or_default(),
+                created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(9)?)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc::now()),
+                updated_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(10)?)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc::now()),
+            })
+        }).ok();
+
+        Ok(entity)
+    }
+
+    pub fn list_entities(&self) -> Result<Vec<GraphEntity>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(&format!(
+            "SELECT id, name, normalized_name, entity_type, aliases, description, trust_score, confirmation_count, metadata, created_at, updated_at FROM {}",
+            TABLE_GRAPH_NODES
+        ))?;
+
+        let rows = stmt.query_map([], |row| {
+            let entity_type_str: String = row.get(3)?;
+            let aliases_str: String = row.get(4)?;
+            let metadata_str: String = row.get(8)?;
+
+            Ok(GraphEntity {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                normalized_name: row.get(2)?,
+                entity_type: GraphEntityType::parse(&entity_type_str).unwrap_or(GraphEntityType::Concept),
+                aliases: serde_json::from_str(&aliases_str).unwrap_or_default(),
+                description: row.get(5)?,
+                trust_score: row.get(6)?,
+                confirmation_count: row.get(7)?,
+                metadata: serde_json::from_str(&metadata_str).unwrap_or_default(),
+                created_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(9)?)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc::now()),
+                updated_at: DateTime::parse_from_rfc3339(&row.get::<_, String>(10)?)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc::now()),
+            })
+        })?;
+
+        let mut entities = Vec::new();
+        for entity in rows {
+            entities.push(entity?);
+        }
+        Ok(entities)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::memory::graph::GraphEntityType;
+
+    #[test]
+    fn test_upsert_entity_deduplication() {
+        let conn = Arc::new(Mutex::new(Connection::open_in_memory().unwrap()));
+        let store = GraphStore::new(conn).unwrap();
+
+        let e1 = GraphEntity::new("Xavier".to_string(), GraphEntityType::Product);
+        let id1 = store.upsert_entity(e1).unwrap();
+
+        let e2 = GraphEntity::new("xavier".to_string(), GraphEntityType::Product);
+        let id2 = store.upsert_entity(e2).unwrap();
+
+        assert_eq!(id1, id2);
+
+        let entity = store.get_entity(&id1).unwrap().unwrap();
+        assert_eq!(entity.confirmation_count, 2);
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -6,6 +6,7 @@ pub mod entities;
 pub mod entity_graph;
 pub mod episodic;
 pub mod file_indexer;
+pub mod graph_store;
 pub mod layers_config;
 pub mod manager;
 pub mod patterns;


### PR DESCRIPTION
This PR implements the foundation for a deterministic Belief Graph in Xavier. It includes strict domain models for entities and relationships, a structured SQLite storage layer with entity deduplication, and an extraction service that enforces the schema. This layer aims to eliminate entity drift and hallucination risks associated with probabilistic vector RAG.

Fixes #316

---
*PR created automatically by Jules for task [39247715252571493](https://jules.google.com/task/39247715252571493) started by @iberi22*