### PR TITLE
Fix Code-Graph Clippy errors and test compilation failures

### DIFF
--- a/benches/hybrid_search.rs
+++ b/benches/hybrid_search.rs
@@ -78,6 +78,9 @@ fn bench_hybrid_search(c: &mut Criterion) {
                     revision: 1,
                     primary: true,
                     parent_id: None,
+                    cluster_id: None,
+                    level: xavier::memory::schema::MemoryLevel::Raw,
+                    relation: None,
                     revisions: Vec::new(),
                 })
                 .await

--- a/src/adapters/inbound/http/handlers/agent.rs
+++ b/src/adapters/inbound/http/handlers/agent.rs
@@ -1,7 +1,7 @@
 use axum::{extract::State, Json};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use crate::adapters::inbound::http::AppState;
-use xavier::coordination::agent_registry::AgentMetadata;
+use crate::coordination::agent_registry::AgentMetadata;
 
 #[derive(Debug, Deserialize)]
 pub struct AgentRegisterPayload {
@@ -20,6 +20,7 @@ pub async fn agent_register_handler(
         name: payload.name,
         capabilities: payload.capabilities.unwrap_or_default(),
         role: payload.role,
+        endpoint: None,
     };
 
     let success = state
@@ -83,7 +84,7 @@ pub struct AgentPushContextPayload {
 }
 
 pub async fn agent_push_context_handler(
-    State(state): State<AppState>,
+    State(_state): State<AppState>,
     axum::extract::Path(agent_id): axum::extract::Path<String>,
     Json(payload): Json<AgentPushContextPayload>,
 ) -> Json<serde_json::Value> {

--- a/src/adapters/inbound/http/handlers/code.rs
+++ b/src/adapters/inbound/http/handlers/code.rs
@@ -3,11 +3,9 @@ use axum::{
     http::{HeaderMap, StatusCode},
     Json,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use crate::adapters::inbound::http::state::check_auth;
 use crate::adapters::inbound::http::AppState;
-use crate::ports::inbound::InputSecurityPort;
-use tracing::info;
 use std::path::Path;
 
 #[derive(Debug, Deserialize)]
@@ -123,7 +121,7 @@ pub async fn code_find_handler(
     }
 
     let query = sec_result.sanitized_input.as_deref().unwrap_or(&sec_result.original_input).to_string();
-    let limit = payload.limit.max(1).min(100);
+    let limit = payload.limit.clamp(1, 100);
 
     let symbols = code_find_symbols(
         &state.code_query,
@@ -201,9 +199,9 @@ pub async fn code_context_handler(
         })));
     }
 
-    let limit = payload.limit.max(1).min(100);
+    let limit = payload.limit.clamp(1, 100);
     let kind_limit = if payload.query.trim().is_empty() { limit } else { 10_000 };
-    let budget_tokens = payload.budget_tokens.max(100).min(8000);
+    let budget_tokens = payload.budget_tokens.clamp(100, 8000);
 
     let mut symbols = if let Some(kind) = payload.kind.as_deref() {
         match kind.to_ascii_lowercase().as_str() {
@@ -261,7 +259,7 @@ fn code_find_symbols(
     pattern: Option<&str>,
     limit: usize,
 ) -> Vec<code_graph::types::Symbol> {
-    let limit = limit.max(1).min(100);
+    let limit = limit.clamp(1, 100);
     let broad_limit = if query.trim().is_empty() { limit } else { 10_000 };
 
     let mut symbols = if let Some(pattern) = pattern.filter(|p| !p.trim().is_empty()) {

--- a/src/adapters/inbound/http/handlers/memory.rs
+++ b/src/adapters/inbound/http/handlers/memory.rs
@@ -3,7 +3,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     Json,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use crate::adapters::inbound::http::state::check_auth;
 use crate::adapters::inbound::http::AppState;
 use crate::domain::memory::{MemoryQueryFilters, MemoryRecord as DomainMemoryRecord};
@@ -78,7 +78,7 @@ pub async fn search_handler(
     }
 
     let effective_query = sec_result.sanitized_input.as_deref().unwrap_or(&sec_result.original_input);
-    let limit = payload.limit.max(1).min(100);
+    let limit = payload.limit.clamp(1, 100);
     info!("Search request: query={}, limit={}", effective_query, limit);
 
     match state.memory.search(effective_query, payload.filters).await {
@@ -118,7 +118,7 @@ pub async fn add_handler(
     Json(payload): Json<AddPayload>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
     check_auth(&headers, &state)?;
-    let mut record = DomainMemoryRecord::new_fact(payload.path.clone(), payload.content);
+    let record = DomainMemoryRecord::new_fact(payload.path.clone(), payload.content);
     // Note: domain metadata translation would go here if needed
 
     match state.memory.add(record).await {
@@ -172,7 +172,7 @@ pub async fn memory_query_handler(
         }));
     }
 
-    let limit = payload.limit.unwrap_or(10).max(1).min(100);
+    let _limit = payload.limit.unwrap_or(10).clamp(1, 100);
     let effective_query = sec_result.sanitized_input.as_deref().unwrap_or(&sec_result.original_input);
 
     match state.memory.search(effective_query, None).await {

--- a/src/adapters/inbound/http/handlers/security.rs
+++ b/src/adapters/inbound/http/handlers/security.rs
@@ -1,5 +1,5 @@
 use axum::{extract::State, Json};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use crate::adapters::inbound::http::AppState;
 
 #[derive(Debug, Deserialize)]

--- a/src/app/change_control_service.rs
+++ b/src/app/change_control_service.rs
@@ -443,7 +443,7 @@ impl ChangeControlPort for ChangeControlService {
             .filter(|t| {
                 t.dependencies.iter().any(|dep_id| {
                     // Blocked if dependency is missing or not yet completed
-                    tasks.get(dep_id).map_or(true, |dep| {
+                    tasks.get(dep_id).is_none_or(|dep| {
                         dep.status != AgentTaskStatus::Completed
                     })
                 })
@@ -455,7 +455,7 @@ impl ChangeControlPort for ChangeControlService {
                     t.dependencies
                         .iter()
                         .filter(|dep_id| {
-                            tasks.get(*dep_id).map_or(true, |dep| {
+                            tasks.get(*dep_id).is_none_or(|dep| {
                                 dep.status != AgentTaskStatus::Completed
                             })
                         })

--- a/src/chronicle/ssg.rs
+++ b/src/chronicle/ssg.rs
@@ -76,6 +76,12 @@ footer { margin-top: 80px; padding: 40px 0; border-top: 1px solid var(--border-c
 /// Default fallback JS (used when theme file is missing)
 const FALLBACK_JS: &str = r#"console.log("Xavier DevLog loaded.");"#;
 
+impl Default for DevLogSSG {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DevLogSSG {
     pub fn new() -> Self {
         Self {
@@ -255,7 +261,7 @@ impl DevLogSSG {
         for entry in WalkDir::new(&self.input_dir).max_depth(1) {
             let entry = entry?;
             let path = entry.path();
-            if path.is_file() && path.extension().map_or(false, |ext| ext == "md") {
+            if path.is_file() && path.extension().is_some_and(|ext| ext == "md") {
                 posts.push(path.to_path_buf());
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,7 +63,7 @@ pub struct CliState {
     pub _time_store: Option<Arc<TimeMetricsStore>>,
     pub agent_registry: Arc<dyn AgentLifecyclePort>,
     pub panel_store: Arc<SessionStore>,
-    pub change_control: Arc<ChangeControlService>,
+    pub _change_control: Arc<ChangeControlService>,
 }
 
 #[derive(Subcommand)]
@@ -359,7 +359,7 @@ async fn start_http_server(port: u16) -> Result<()> {
         _time_store: Some(time_store),
         agent_registry: SimpleAgentRegistry::new() as Arc<dyn AgentLifecyclePort>,
         panel_store,
-        change_control,
+        _change_control: change_control,
     };
 
     info!(
@@ -3417,7 +3417,7 @@ mod tests {
         // This test runs last and may be affected by env state from other tests.
         // If XAVIER_TOKEN is still set, we expect 401 (wrong token).
         // If unset, we expect 500 (not configured). Both are acceptable for this test.
-        let token_is_set = std::env::var("XAVIER_TOKEN").is_ok();
+        let _token_is_set = std::env::var("XAVIER_TOKEN").is_ok();
 
         let app = Router::new()
             .route("/protected", get(|| async { "ok" }))

--- a/src/devlog/generator.rs
+++ b/src/devlog/generator.rs
@@ -5,6 +5,12 @@ use std::path::Path;
 
 pub struct Generator;
 
+impl Default for Generator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Generator {
     pub fn new() -> Self {
         Self

--- a/src/domain/agent.rs
+++ b/src/domain/agent.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Active agent entry tracked by the lifecycle registry.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentEntry {
     pub agent_id: String,
     pub session_id: String,

--- a/src/installer/wizard.rs
+++ b/src/installer/wizard.rs
@@ -246,8 +246,8 @@ fn render(f: &mut Frame, state: &InstallerState) {
     );
 
     // Main layout: centered card
-    let card_w = (area.width.min(72)).max(40);
-    let card_h = (area.height.min(22)).max(12);
+    let card_w = area.width.clamp(40, 72);
+    let card_h = area.height.clamp(12, 22);
     let card_x = (area.width.saturating_sub(card_w)) / 2;
     let card_y = (area.height.saturating_sub(card_h)) / 2;
     let card = Rect::new(card_x, card_y, card_w, card_h);
@@ -293,7 +293,7 @@ fn progress_bar(steps: &[WizardStep], current: WizardStep) -> Line<'_> {
             spans.push(Span::raw(" · "));
         }
         if *step == current {
-            spans.push(Span::styled(format!("●"), Style::default().fg(ACCENT)));
+            spans.push(Span::styled("●".to_string(), Style::default().fg(ACCENT)));
         } else if step_order(*step) < step_order(current) {
             spans.push(Span::styled("●", Style::default().fg(SUCCESS)));
         } else {

--- a/src/installer/wizard_test.rs
+++ b/src/installer/wizard_test.rs
@@ -42,7 +42,7 @@ mod tests {
                 f,
                 Rect::new(0, 0, 40, 1),
                 "Label",
-                "Value",
+                "🦀Rust",
                 false,
                 0,
                 false,
@@ -60,16 +60,10 @@ mod tests {
 
 
         // Check emoji
-        assert_eq!(buf[(6, 0)].symbol(), "🦀");
+        assert_eq!(buf[(7, 0)].symbol(), "🦀");
 
-        // The emoji 🦀 is width 2. Ratatui renders it in one cell and
-        // usually leaves the next cell empty or with a generic filler.
-        // In this environment, it seems cell 7 is a space.
-        let rust_start = if buf[(7, 0)].symbol() == " " || buf[(7, 0)].symbol() == "" {
-            8
-        } else {
-            7
-        };
+        // The emoji 🦀 is width 2. Index 8 is the filler.
+        let rust_start = 9;
 
         let mut rust = String::new();
         for i in rust_start..rust_start+4 {
@@ -99,7 +93,7 @@ mod tests {
         // "Input: " (7) + "A" (1) + "🦀" (1) + "C" (1) = 10
         // Cursor at pos 1 of "A🦀C" means it's on "🦀"
         assert_eq!(buf[(8, 0)].symbol(), "🦀");
-        // Check background color of cursor cell (ACCENT is Cyan)
+        // Check background color of cursor cell (ACCENT is Color::Cyan)
         // ACCENT is Color::Cyan
         use ratatui::style::Color;
         assert_eq!(buf[(8, 0)].bg, Color::Cyan);

--- a/src/main_installer.rs
+++ b/src/main_installer.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             println!("✗ Wizard cancelled.");
         }
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(feature = "cli-interactive"))]

--- a/src/memory/sqlite_vec_store.rs
+++ b/src/memory/sqlite_vec_store.rs
@@ -2705,6 +2705,9 @@ mod tests {
                     revision INTEGER NOT NULL DEFAULT 1,
                     primary_flag INTEGER NOT NULL DEFAULT 1,
                     parent_id TEXT,
+                    cluster_id TEXT,
+                    level TEXT NOT NULL DEFAULT 'raw',
+                    relation TEXT,
                     revisions TEXT NOT NULL DEFAULT '[]'
                 );
                 CREATE VIRTUAL TABLE memory_fts USING fts5(

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -164,6 +164,29 @@ pub(crate) struct DurableStoreFile {
 // ---------------------------------------------------------------------------
 
 impl MemoryRecord {
+    pub fn new_fact(path: String, content: String) -> Self {
+        let now = Utc::now();
+        Self {
+            id: stable_key("memory", &["default", &path]),
+            workspace_id: "default".to_string(),
+            path,
+            content,
+            metadata: serde_json::json!({
+                "kind": "fact",
+            }),
+            embedding: vec![],
+            created_at: now,
+            updated_at: now,
+            revision: 1,
+            primary: true,
+            parent_id: None,
+            cluster_id: None,
+            level: MemoryLevel::Raw,
+            relation: None,
+            revisions: vec![],
+        }
+    }
+
     pub fn from_document(
         workspace_id: &str,
         document: &MemoryDocument,

--- a/tests/sync_check_handler_cached_result.rs
+++ b/tests/sync_check_handler_cached_result.rs
@@ -45,6 +45,22 @@ impl MemoryStore for MockMemoryStore {
         Ok(self.records.clone())
     }
 
+    async fn export(&self, _path: &std::path::Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn export_tree(
+        &self,
+        _workspace_id: &str,
+        _path: &std::path::Path,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn import(&self, _path: &std::path::Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn update(&self, _record: MemoryRecord) -> anyhow::Result<()> {
         Ok(())
     }
@@ -181,6 +197,9 @@ fn make_session_record(seconds_ago: i64) -> MemoryRecord {
         revision: 1,
         primary: true,
         parent_id: None,
+        cluster_id: None,
+        level: xavier::memory::schema::MemoryLevel::Raw,
+        relation: None,
         revisions: vec![],
     }
 }


### PR DESCRIPTION
This PR addresses CI failures from PR #253 by fixing all auto-fixable Clippy errors (and several manual ones), resolving test compilation errors caused by missing fields and trait methods, and eliminating build warnings.

Key fixes include:
- Implementing `MemoryRecord::new_fact` and updating all `MemoryRecord` initializations to include `cluster_id`, `level`, and `relation`.
- Updating `MockMemoryStore` in tests to satisfy the updated `MemoryStore` trait.
- Suppressing `dead_code` warnings in `CliState`.
- Adopting idiomatic Rust patterns like `.clamp()` and `.is_none_or()`.
- Fixing regression in TUI installer multibyte character tests.

All tests in the `xavier` crate pass with `ci-safe` features, and clippy is clean.

Fixes #267

---
*PR created automatically by Jules for task [14023254985881098115](https://jules.google.com/task/14023254985881098115) started by @iberi22*