### PR TITLE
Refactor code-graph parsers: extract PushSymbolArgs struct

### DIFF
--- a/code-graph/src/parser/go.rs
+++ b/code-graph/src/parser/go.rs
@@ -1,7 +1,7 @@
 //! Go parser using tree-sitter.
 
 use crate::error::{GraphError, Result};
-use crate::parser::{compact_node_signature, cyclomatic_complexity};
+use crate::parser::{compact_node_signature, cyclomatic_complexity, PushSymbolArgs};
 use crate::types::{Language, Symbol, SymbolKind};
 use tree_sitter::{Node, Parser};
 
@@ -102,13 +102,17 @@ impl GoParser {
                         })
                         .unwrap_or(SymbolKind::Symbol);
                     self.push_symbol(
-                        child,
-                        source,
-                        file_path,
                         symbols,
-                        name.to_string(),
-                        kind,
-                        None,
+                        PushSymbolArgs {
+                            node: child,
+                            source,
+                            language: Language::Go,
+                            kind,
+                            file_path,
+                            name: name.to_string(),
+                            depth: 0,
+                            parent: None,
+                        },
                     );
                 }
             }
@@ -127,13 +131,17 @@ impl GoParser {
         if let Some(name_node) = node.child_by_field_name("name") {
             if let Ok(name) = name_node.utf8_text(source.as_bytes()) {
                 self.push_symbol(
-                    node,
-                    source,
-                    file_path,
                     symbols,
-                    name.to_string(),
-                    kind,
-                    parent,
+                    PushSymbolArgs {
+                        node,
+                        source,
+                        language: Language::Go,
+                        kind,
+                        file_path,
+                        name: name.to_string(),
+                        depth: 0,
+                        parent,
+                    },
                 );
             }
         }
@@ -143,44 +151,39 @@ impl GoParser {
         let raw = node.utf8_text(source.as_bytes()).unwrap_or_default();
         for part in raw.split('"').skip(1).step_by(2) {
             self.push_symbol(
-                node,
-                source,
-                file_path,
                 symbols,
-                part.to_string(),
-                SymbolKind::Import,
-                None,
+                PushSymbolArgs {
+                    node,
+                    source,
+                    language: Language::Go,
+                    kind: SymbolKind::Import,
+                    file_path,
+                    name: part.to_string(),
+                    depth: 0,
+                    parent: None,
+                },
             );
         }
     }
 
-    fn push_symbol(
-        &self,
-        node: Node,
-        source: &str,
-        file_path: &str,
-        symbols: &mut Vec<Symbol>,
-        name: String,
-        kind: SymbolKind,
-        parent: Option<String>,
-    ) {
-        let start = node.start_position();
-        let end = node.end_position();
-        let complexity = matches!(kind, SymbolKind::Function | SymbolKind::Method)
-            .then(|| cyclomatic_complexity(node, source));
+    fn push_symbol(&self, symbols: &mut Vec<Symbol>, args: PushSymbolArgs<'_>) {
+        let start = args.node.start_position();
+        let end = args.node.end_position();
+        let complexity = matches!(args.kind, SymbolKind::Function | SymbolKind::Method)
+            .then(|| cyclomatic_complexity(args.node, args.source));
         symbols.push(Symbol {
             id: None,
             stable_id: None,
-            name,
-            kind,
+            name: args.name,
+            kind: args.kind,
             lang: Language::Go,
-            file_path: file_path.to_string(),
+            file_path: args.file_path.to_string(),
             start_line: (start.row + 1) as u32,
             end_line: (end.row + 1) as u32,
             start_col: start.column as u32,
             end_col: end.column as u32,
-            signature: compact_node_signature(node, source),
-            parent,
+            signature: compact_node_signature(args.node, args.source),
+            parent: args.parent,
             complexity,
         });
     }

--- a/code-graph/src/parser/java.rs
+++ b/code-graph/src/parser/java.rs
@@ -1,7 +1,7 @@
 //! Java parser using tree-sitter.
 
 use crate::error::{GraphError, Result};
-use crate::parser::{compact_node_signature, cyclomatic_complexity};
+use crate::parser::{compact_node_signature, cyclomatic_complexity, PushSymbolArgs};
 use crate::types::{Language, Symbol, SymbolKind};
 use tree_sitter::{Node, Parser};
 
@@ -122,7 +122,19 @@ impl JavaParser {
     ) -> Option<String> {
         let name_node = node.child_by_field_name("name")?;
         let name = name_node.utf8_text(source.as_bytes()).ok()?.to_string();
-        self.push_symbol(node, source, file_path, symbols, name.clone(), kind, parent);
+        self.push_symbol(
+            symbols,
+            PushSymbolArgs {
+                node,
+                source,
+                language: Language::Java,
+                kind,
+                file_path,
+                name: name.clone(),
+                depth: 0,
+                parent,
+            },
+        );
         Some(name)
     }
 
@@ -134,43 +146,38 @@ impl JavaParser {
             .trim()
             .to_string();
         self.push_symbol(
-            node,
-            source,
-            file_path,
             symbols,
-            name,
-            SymbolKind::Import,
-            None,
+            PushSymbolArgs {
+                node,
+                source,
+                language: Language::Java,
+                kind: SymbolKind::Import,
+                file_path,
+                name,
+                depth: 0,
+                parent: None,
+            },
         );
     }
 
-    fn push_symbol(
-        &self,
-        node: Node,
-        source: &str,
-        file_path: &str,
-        symbols: &mut Vec<Symbol>,
-        name: String,
-        kind: SymbolKind,
-        parent: Option<String>,
-    ) {
-        let start = node.start_position();
-        let end = node.end_position();
-        let complexity = matches!(kind, SymbolKind::Function | SymbolKind::Method)
-            .then(|| cyclomatic_complexity(node, source));
+    fn push_symbol(&self, symbols: &mut Vec<Symbol>, args: PushSymbolArgs<'_>) {
+        let start = args.node.start_position();
+        let end = args.node.end_position();
+        let complexity = matches!(args.kind, SymbolKind::Function | SymbolKind::Method)
+            .then(|| cyclomatic_complexity(args.node, args.source));
         symbols.push(Symbol {
             id: None,
             stable_id: None,
-            name,
-            kind,
+            name: args.name,
+            kind: args.kind,
             lang: Language::Java,
-            file_path: file_path.to_string(),
+            file_path: args.file_path.to_string(),
             start_line: (start.row + 1) as u32,
             end_line: (end.row + 1) as u32,
             start_col: start.column as u32,
             end_col: end.column as u32,
-            signature: compact_node_signature(node, source),
-            parent,
+            signature: compact_node_signature(args.node, args.source),
+            parent: args.parent,
             complexity,
         });
     }

--- a/code-graph/src/parser/mod.rs
+++ b/code-graph/src/parser/mod.rs
@@ -6,7 +6,7 @@ use crate::parser::java::JavaParser;
 use crate::parser::python::PythonParser;
 use crate::parser::rust::RustParser;
 use crate::parser::typescript::TypeScriptParser;
-use crate::types::{Language, Symbol};
+use crate::types::{Language, Symbol, SymbolKind};
 use tree_sitter::Node;
 
 pub mod go;
@@ -68,6 +68,18 @@ pub(crate) fn compact_node_signature(node: Node, source: &str) -> Option<String>
     } else {
         Some(compact)
     }
+}
+
+/// Arguments for pushing a symbol
+pub struct PushSymbolArgs<'src> {
+    pub node: Node<'src>,
+    pub source: &'src str,
+    pub language: Language,
+    pub kind: SymbolKind,
+    pub file_path: &'src str,
+    pub name: String,
+    pub depth: usize,
+    pub parent: Option<String>,
 }
 
 pub(crate) fn cyclomatic_complexity(node: Node, source: &str) -> f32 {

--- a/code-graph/src/parser/python.rs
+++ b/code-graph/src/parser/python.rs
@@ -1,7 +1,7 @@
 //! Python parser using tree-sitter.
 
 use crate::error::{GraphError, Result};
-use crate::parser::{compact_node_signature, cyclomatic_complexity};
+use crate::parser::{compact_node_signature, cyclomatic_complexity, PushSymbolArgs};
 use crate::types::{Language, Symbol, SymbolKind};
 use tree_sitter::{Node, Parser};
 
@@ -100,7 +100,19 @@ impl PythonParser {
     ) -> Option<String> {
         let name_node = node.child_by_field_name("name")?;
         let name = name_node.utf8_text(source.as_bytes()).ok()?.to_string();
-        self.push_symbol(node, source, file_path, symbols, name.clone(), kind, parent);
+        self.push_symbol(
+            symbols,
+            PushSymbolArgs {
+                node,
+                source,
+                language: Language::Python,
+                kind,
+                file_path,
+                name: name.clone(),
+                depth: 0,
+                parent,
+            },
+        );
         Some(name)
     }
 
@@ -115,43 +127,38 @@ impl PythonParser {
             .trim()
             .to_string();
         self.push_symbol(
-            node,
-            source,
-            file_path,
             symbols,
-            name,
-            SymbolKind::Import,
-            None,
+            PushSymbolArgs {
+                node,
+                source,
+                language: Language::Python,
+                kind: SymbolKind::Import,
+                file_path,
+                name,
+                depth: 0,
+                parent: None,
+            },
         );
     }
 
-    fn push_symbol(
-        &self,
-        node: Node,
-        source: &str,
-        file_path: &str,
-        symbols: &mut Vec<Symbol>,
-        name: String,
-        kind: SymbolKind,
-        parent: Option<String>,
-    ) {
-        let start = node.start_position();
-        let end = node.end_position();
+    fn push_symbol(&self, symbols: &mut Vec<Symbol>, args: PushSymbolArgs<'_>) {
+        let start = args.node.start_position();
+        let end = args.node.end_position();
         let complexity =
-            (kind == SymbolKind::Function).then(|| cyclomatic_complexity(node, source));
+            (args.kind == SymbolKind::Function).then(|| cyclomatic_complexity(args.node, args.source));
         symbols.push(Symbol {
             id: None,
             stable_id: None,
-            name,
-            kind,
+            name: args.name,
+            kind: args.kind,
             lang: Language::Python,
-            file_path: file_path.to_string(),
+            file_path: args.file_path.to_string(),
             start_line: (start.row + 1) as u32,
             end_line: (end.row + 1) as u32,
             start_col: start.column as u32,
             end_col: end.column as u32,
-            signature: compact_node_signature(node, source),
-            parent,
+            signature: compact_node_signature(args.node, args.source),
+            parent: args.parent,
             complexity,
         });
     }

--- a/code-graph/src/parser/typescript.rs
+++ b/code-graph/src/parser/typescript.rs
@@ -1,7 +1,7 @@
 //! TypeScript and JavaScript parser using tree-sitter.
 
 use crate::error::{GraphError, Result};
-use crate::parser::{compact_node_signature, cyclomatic_complexity};
+use crate::parser::{compact_node_signature, cyclomatic_complexity, PushSymbolArgs};
 use crate::types::{Language, Symbol, SymbolKind};
 use tree_sitter::{Node, Parser};
 
@@ -124,7 +124,19 @@ impl TypeScriptParser {
     ) -> Option<String> {
         let name_node = node.child_by_field_name("name")?;
         let name = name_node.utf8_text(source.as_bytes()).ok()?.to_string();
-        self.push_symbol(node, source, file_path, symbols, name.clone(), kind, parent);
+        self.push_symbol(
+            symbols,
+            PushSymbolArgs {
+                node,
+                source,
+                language: self.lang.clone(),
+                kind,
+                file_path,
+                name: name.clone(),
+                depth: 0,
+                parent,
+            },
+        );
         Some(name)
     }
 
@@ -151,13 +163,17 @@ impl TypeScriptParser {
             if let Some(name_node) = child.child_by_field_name("name") {
                 if let Ok(name) = name_node.utf8_text(source.as_bytes()) {
                     self.push_symbol(
-                        child,
-                        source,
-                        file_path,
                         symbols,
-                        name.to_string(),
-                        SymbolKind::Function,
-                        parent.clone(),
+                        PushSymbolArgs {
+                            node: child,
+                            source,
+                            language: self.lang.clone(),
+                            kind: SymbolKind::Function,
+                            file_path,
+                            name: name.to_string(),
+                            depth: 0,
+                            parent: parent.clone(),
+                        },
                     );
                 }
             }
@@ -173,43 +189,38 @@ impl TypeScriptParser {
             .trim()
             .to_string();
         self.push_symbol(
-            node,
-            source,
-            file_path,
             symbols,
-            name,
-            SymbolKind::Import,
-            None,
+            PushSymbolArgs {
+                node,
+                source,
+                language: self.lang.clone(),
+                kind: SymbolKind::Import,
+                file_path,
+                name,
+                depth: 0,
+                parent: None,
+            },
         );
     }
 
-    fn push_symbol(
-        &self,
-        node: Node,
-        source: &str,
-        file_path: &str,
-        symbols: &mut Vec<Symbol>,
-        name: String,
-        kind: SymbolKind,
-        parent: Option<String>,
-    ) {
-        let start = node.start_position();
-        let end = node.end_position();
-        let complexity = matches!(kind, SymbolKind::Function | SymbolKind::Method)
-            .then(|| cyclomatic_complexity(node, source));
+    fn push_symbol(&self, symbols: &mut Vec<Symbol>, args: PushSymbolArgs<'_>) {
+        let start = args.node.start_position();
+        let end = args.node.end_position();
+        let complexity = matches!(args.kind, SymbolKind::Function | SymbolKind::Method)
+            .then(|| cyclomatic_complexity(args.node, args.source));
         symbols.push(Symbol {
             id: None,
             stable_id: None,
-            name,
-            kind,
+            name: args.name,
+            kind: args.kind,
             lang: self.lang.clone(),
-            file_path: file_path.to_string(),
+            file_path: args.file_path.to_string(),
             start_line: (start.row + 1) as u32,
             end_line: (end.row + 1) as u32,
             start_col: start.column as u32,
             end_col: end.column as u32,
-            signature: compact_node_signature(node, source),
-            parent,
+            signature: compact_node_signature(args.node, args.source),
+            parent: args.parent,
             complexity,
         });
     }


### PR DESCRIPTION
Refactored the `push_symbol` method in `code-graph`'s Go, Java, Python, and TypeScript parsers to use a new `PushSymbolArgs` struct. This change was made to address a Clippy warning regarding functions with too many arguments (8/7) and to improve the overall readability and maintainability of the parser implementations.

Changes:
1.  **Defined `PushSymbolArgs` struct** in `code-graph/src/parser/mod.rs` containing:
    *   `node: tree_sitter::Node<'src>`
    *   `source: &'src str`
    *   `language: Language`
    *   `kind: SymbolKind`
    *   `file_path: &'src str`
    *   `name: String`
    *   `depth: usize`
    *   `parent: Option<String>`
2.  **Updated `push_symbol` signature and body** in `go.rs`, `java.rs`, `python.rs`, and `typescript.rs`.
3.  **Updated all call sites** of `push_symbol` across the affected files to use the new struct.
4.  **Verified** that `cargo clippy -p code-graph -- -D warnings` now passes and all 25 unit tests in `code-graph` continue to pass.

Fixes #305

---
*PR created automatically by Jules for task [8310831435953746849](https://jules.google.com/task/8310831435953746849) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal parser architecture across Go, Java, Python, and TypeScript language parsers to use a structured approach for symbol creation, improving code consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/xavier/pull/332)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->