### PR TITLE
Token budget enforcement in context assembly pipeline

### DIFF
--- a/src/agents/runtime.rs
+++ b/src/agents/runtime.rs
@@ -22,6 +22,8 @@ use crate::memory::qmd_memory::QmdMemory;
 use crate::memory::schema::MemoryQueryFilters;
 use crate::scheduler::JobScheduler;
 
+pub const DEFAULT_CONTEXT_BUDGET: usize = 4000;
+
 /// Estado de la sesión
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
@@ -462,10 +464,14 @@ impl AgentRuntime {
                 }
             }
 
-            let retrieval_result = self
+            let mut retrieval_result = self
                 .system1
                 .run_with_filters_and_budget(&current_query, None, filters.as_ref(), budget)
                 .await?;
+
+            // Explicitly enforce budget on the result
+            retrieval_result.truncate_to_budget(budget);
+
             s1_total_ms += s1_start.elapsed().as_millis() as u64;
 
             debug!(

--- a/src/agents/system1.rs
+++ b/src/agents/system1.rs
@@ -21,6 +21,31 @@ pub struct RetrievalResult {
     pub total_results: usize,
 }
 
+impl RetrievalResult {
+    /// Truncate results to fit the token budget (greedy fill by relevance)
+    pub fn truncate_to_budget(&mut self, budget_tokens: usize) {
+        let mut total_tokens = 0;
+        let mut final_documents = Vec::new();
+
+        for doc in std::mem::take(&mut self.documents) {
+            if total_tokens + doc.token_count <= budget_tokens {
+                total_tokens += doc.token_count;
+                final_documents.push(doc);
+            } else if final_documents.is_empty() {
+                // If the first document alone exceeds budget, we still skip it to strictly enforce budget,
+                // or we could partially truncate it. The requirement says "hard cap".
+                // We'll skip it for now to be safe, as it's the simplest "hard cap" implementation.
+                break;
+            } else {
+                break;
+            }
+        }
+
+        self.documents = final_documents;
+        self.total_results = self.documents.len();
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RetrievedDocument {
     pub id: String,
@@ -223,7 +248,7 @@ impl System1Retriever {
             .into_iter()
             .enumerate()
             .map(|(index, doc)| {
-                let token_count = doc.content.split_whitespace().count();
+                let token_count = estimate_tokens(&doc.content);
                 RetrievedDocument {
                     id: doc
                         .id
@@ -272,7 +297,7 @@ impl System1Retriever {
                         .iter()
                         .any(|d| d.id == doc.id.clone().unwrap_or_default() || d.path == doc.path)
                     {
-                        let token_count = doc.content.split_whitespace().count();
+                        let token_count = estimate_tokens(&doc.content);
                         documents.push(RetrievedDocument {
                             id: doc.id.unwrap_or_default(),
                             path: doc.path,
@@ -297,7 +322,7 @@ impl System1Retriever {
                         .iter()
                         .any(|d| d.id == doc.id.clone().unwrap_or_default() || d.path == doc.path)
                     {
-                        let token_count = doc.content.split_whitespace().count();
+                        let token_count = estimate_tokens(&doc.content);
                         documents.push(RetrievedDocument {
                             id: doc.id.unwrap_or_default(),
                             path: doc.path,
@@ -327,7 +352,7 @@ impl System1Retriever {
                     .collect::<Vec<_>>()
                     .join("\n");
 
-                let token_count = belief_text.split_whitespace().count();
+                let token_count = estimate_tokens(&belief_text);
                 documents.push(RetrievedDocument {
                     id: "belief_graph_context".to_string(),
                     path: "belief_graph".to_string(),
@@ -341,42 +366,28 @@ impl System1Retriever {
 
         rank_documents_for_query(query, &mut documents);
 
-        // Budget enforcement: Truncate documents to fit within max_tokens
-        let mut total_tokens = 0;
-        let mut final_documents = Vec::new();
-
-        for doc in documents {
-            if total_tokens + doc.token_count <= max_tokens {
-                total_tokens += doc.token_count;
-                final_documents.push(doc);
-            } else if final_documents.is_empty() {
-                // Always include at least the first document (possibly truncated) to avoid empty context
-                // but for now, we just skip it if it's too large, or we could truncate its content.
-                // Xavier policy is usually to skip or truncate. Let's keep it simple: skip if it blows the budget
-                // unless it's the very first one and we want at least something.
-                // Requirement: "truncate results to fit the token budget (greedy fill by relevance)"
-                break;
-            } else {
-                break;
-            }
-        }
-        documents = final_documents;
-
-        let total = documents.len();
-
-        info!(
-            "✅ System1 retrieved {} documents in {:?}",
-            total,
-            start.elapsed()
-        );
-
-        Ok(RetrievalResult {
+        let mut result = RetrievalResult {
             query: query.to_string(),
             documents,
             search_type: selected_search_type,
-            total_results: total,
-        })
+            total_results: 0, // Will be updated by truncate_to_budget
+        };
+
+        // Budget enforcement: Truncate documents to fit within max_tokens
+        result.truncate_to_budget(max_tokens);
+
+        info!(
+            "✅ System1 retrieved {} documents in {:?}",
+            result.total_results,
+            start.elapsed()
+        );
+
+        Ok(result)
     }
+}
+
+fn estimate_tokens(text: &str) -> usize {
+    (text.len() / 4).max(1)
 }
 
 fn query_terms(query: &str) -> Vec<String> {


### PR DESCRIPTION
This change enforces a hard cap on retrieved context in the Xavier agent pipeline to prevent token waste. It introduces a rough token estimator (4 characters per token) and a greedy truncation method in `RetrievalResult` that keeps the most relevant documents within the specified budget. The `AgentRuntime` now explicitly calls this truncation after System 1 retrieval.

Fixes #289

---
*PR created automatically by Jules for task [10202821537009435548](https://jules.google.com/task/10202821537009435548) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced context budget enforcement to limit retrieval results by token count, preventing system resource overflow.
  * Set default context budget to 4,000 tokens for improved resource management and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/xavier/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->