### PR TITLE
Resolve critical deadlocks in memory manager

### DIFF
--- a/src/memory/manager.rs
+++ b/src/memory/manager.rs
@@ -373,11 +373,13 @@ impl MemoryManager {
     /// Initialize tracking for a new document
     pub fn track_new_document(&self, doc: &MemoryDocument) {
         if let Some(id) = &doc.id {
-            let mut times = self
-                .created_times
-                .lock()
-                .expect("manager: created_times lock poisoned");
-            times.insert(id.clone(), Utc::now());
+            {
+                let mut times = self
+                    .created_times
+                    .lock()
+                    .expect("manager: created_times lock poisoned");
+                times.insert(id.clone(), Utc::now());
+            }
 
             let mut relevance = self
                 .relevance_scores
@@ -400,15 +402,6 @@ impl MemoryManager {
             decayed_count: 0,
         };
 
-        let counts = self
-            .access_counts
-            .lock()
-            .expect("manager: access_counts lock poisoned");
-        let times = self
-            .last_access_times
-            .lock()
-            .expect("manager: last_access_times lock poisoned");
-
         for doc in docs {
             let priority = MemoryPriority::from_metadata(&doc.metadata);
             *stats
@@ -416,13 +409,19 @@ impl MemoryManager {
                 .entry(priority.as_str().to_string())
                 .or_insert(0) += 1;
 
-            let access_count = doc
-                .id
-                .as_ref()
-                .and_then(|id| counts.get(id))
-                .copied()
-                .unwrap_or(0);
-            let last_access = doc.id.as_ref().and_then(|id| times.get(id)).copied();
+            let (access_count, last_access) = if let Some(id) = &doc.id {
+                let counts = self
+                    .access_counts
+                    .lock()
+                    .expect("manager: access_counts lock poisoned");
+                let times = self
+                    .last_access_times
+                    .lock()
+                    .expect("manager: last_access_times lock poisoned");
+                (counts.get(id).copied().unwrap_or(0), times.get(id).copied())
+            } else {
+                (0, None)
+            };
 
             let mut verified = false;
             if let (Some(graph_lock), Some(doc_id)) = (&self._belief_graph, &doc.id) {
@@ -458,34 +457,32 @@ impl MemoryManager {
     /// Get all managed memories with their quality scores
     pub async fn get_all_memories(&self) -> Result<Vec<ManagedMemory>> {
         let docs = self.memory.all_documents().await;
-        let counts = self
-            .access_counts
-            .lock()
-            .expect("manager: access_counts lock poisoned");
-        let times = self
-            .last_access_times
-            .lock()
-            .expect("manager: last_access_times lock poisoned");
-        let created = self
-            .created_times
-            .lock()
-            .expect("manager: created_times lock poisoned");
-        let _relevance = self
-            .relevance_scores
-            .lock()
-            .expect("manager: relevance_scores lock poisoned");
 
         let mut memories = Vec::new();
         for doc in docs {
             let priority = MemoryPriority::from_metadata(&doc.metadata);
-            let access_count = doc
-                .id
-                .as_ref()
-                .and_then(|id| counts.get(id))
-                .copied()
-                .unwrap_or(0);
-            let last_access = doc.id.as_ref().and_then(|id| times.get(id)).copied();
-            let created_at = doc.id.as_ref().and_then(|id| created.get(id)).copied();
+            let (access_count, last_access, created_at) = if let Some(id) = &doc.id {
+                let counts = self
+                    .access_counts
+                    .lock()
+                    .expect("manager: access_counts lock poisoned");
+                let times = self
+                    .last_access_times
+                    .lock()
+                    .expect("manager: last_access_times lock poisoned");
+                let created = self
+                    .created_times
+                    .lock()
+                    .expect("manager: created_times lock poisoned");
+
+                (
+                    counts.get(id).copied().unwrap_or(0),
+                    times.get(id).copied(),
+                    created.get(id).copied(),
+                )
+            } else {
+                (0, None, None)
+            };
 
             let mut verified = false;
             if let (Some(graph_lock), Some(doc_id)) = (&self._belief_graph, &doc.id) {


### PR DESCRIPTION
I have resolved the critical deadlocks in `src/memory/manager.rs` identified in the diagnostic report.

### Changes:
1.  **Refactored `get_stats` and `get_all_memories`**: These methods were holding `std::sync::MutexGuard`s across `.await` points (specifically when awaiting `has_supporting_beliefs` on the belief graph). I modified the loops to acquire and release the locks within each iteration, ensuring no locks are held during the asynchronous calls.
2.  **Improved `track_new_document`**: I reduced the scope of the `created_times` lock to ensure it is dropped before the `relevance_scores` lock is acquired, preventing potential lock inversion issues.
3.  **Removed Unused Locks**: Cleaned up an unused lock acquisition in `get_all_memories`.

### Verification:
-   **Compilation**: `cargo check` passed successfully, confirming that the futures no longer hold `MutexGuard`s across `await` points.
-   **Unit Tests**: Ran `cargo test memory::manager --lib`, and all tests passed.
-   **Code Review**: The changes were reviewed and confirmed to correctly address the deadlock risks while following Rust async best practices.

Fixes #336

---
*PR created automatically by Jules for task [8656303588510355212](https://jules.google.com/task/8656303588510355212) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory management operations for improved performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/xavier/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->