### PR TITLE
Refactor and modularize sqlite_vec_store.rs

### DIFF
--- a/src/memory/sqlite_vec_store/config.rs
+++ b/src/memory/sqlite_vec_store/config.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use anyhow::Result;
+use crate::settings::XavierSettings;
+
+pub const DB_FILENAME: &str = "xavier_memory_vec.db";
+pub const DEFAULT_EMBEDDING_DIMENSIONS: usize = 768;
+pub const DEFAULT_RRF_K: usize = 60;
+pub const DEFAULT_VECTOR_WEIGHT: f32 = 0.40;
+pub const DEFAULT_FTS_WEIGHT: f32 = 0.35;
+pub const DEFAULT_KG_WEIGHT: f32 = 0.25;
+pub const DEFAULT_QJL_THRESHOLD: usize = 30_000;
+pub const QJL_MAGIC: &[u8; 4] = b"QJL2";
+pub static SQLITE_VEC_EXTENSION_INIT: OnceLock<Result<(), String>> = OnceLock::new();
+
+#[derive(Debug, Clone)]
+pub struct VecSqliteStoreConfig {
+    pub path: PathBuf,
+    pub embedding_dimensions: usize,
+}
+
+impl VecSqliteStoreConfig {
+    pub fn from_env() -> Self {
+        let settings = XavierSettings::current();
+        let embedding_dimensions = std::env::var("XAVIER_EMBEDDING_DIMENSIONS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or({
+                if settings.memory.embedding_dimensions == 0 {
+                    DEFAULT_EMBEDDING_DIMENSIONS
+                } else {
+                    settings.memory.embedding_dimensions
+                }
+            });
+
+        Self {
+            path: std::env::var("XAVIER_MEMORY_VEC_PATH")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| {
+                    if settings.memory.vec_path.trim().is_empty() {
+                        PathBuf::from(&settings.memory.data_dir).join(DB_FILENAME)
+                    } else {
+                        PathBuf::from(&settings.memory.vec_path)
+                    }
+                }),
+            embedding_dimensions,
+        }
+    }
+
+    pub fn detail(&self) -> String {
+        format!(
+            "{} ({}d embeddings)",
+            self.path.display(),
+            self.embedding_dimensions
+        )
+    }
+}

--- a/src/memory/sqlite_vec_store/utils.rs
+++ b/src/memory/sqlite_vec_store/utils.rs
@@ -1,0 +1,89 @@
+use std::collections::HashSet;
+use std::sync::OnceLock;
+use regex::Regex;
+use crate::memory::store::SessionTokenRecord;
+
+pub struct SessionTokenRow {
+    pub token: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub expires_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<SessionTokenRow> for SessionTokenRecord {
+    fn from(value: SessionTokenRow) -> Self {
+        Self {
+            token: value.token,
+            created_at: value.created_at,
+            expires_at: value.expires_at,
+        }
+    }
+}
+
+pub fn search_tokens(query: &str) -> Vec<String> {
+    static TOKEN_RE: OnceLock<Regex> = OnceLock::new();
+    let re = TOKEN_RE.get_or_init(|| {
+        Regex::new(r"[A-Za-z0-9][A-Za-z0-9._:/#-]{1,}").expect("valid search token regex")
+    });
+
+    let mut seen = HashSet::new();
+    re.find_iter(query)
+        .filter_map(|m| {
+            let token = m.as_str().trim_matches('"').trim().to_string();
+            if token.len() < 2 {
+                return None;
+            }
+            let lowered = token.to_ascii_lowercase();
+            if seen.insert(lowered) {
+                Some(token)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+pub fn split_camel_case(token: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut previous_lower = false;
+    for ch in token.chars() {
+        if !ch.is_ascii_alphanumeric() {
+            if !current.is_empty() {
+                words.push(current.clone());
+                current.clear();
+            }
+            previous_lower = false;
+            continue;
+        }
+
+        let is_upper = ch.is_ascii_uppercase();
+        if is_upper && previous_lower && !current.is_empty() {
+            words.push(current.clone());
+            current.clear();
+        }
+        previous_lower = ch.is_ascii_lowercase();
+        current.push(ch.to_ascii_lowercase());
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    words
+}
+
+pub fn code_tokens(text: &str) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut expanded = Vec::new();
+    for token in search_tokens(text) {
+        for segment in token
+            .split(|ch: char| ['_', '-', '/', '.', ':'].contains(&ch))
+            .filter(|segment| !segment.is_empty())
+        {
+            for part in split_camel_case(segment) {
+                if part.len() > 1 && seen.insert(part.clone()) {
+                    expanded.push(part);
+                }
+            }
+        }
+    }
+    expanded
+}


### PR DESCRIPTION
Modularized the large `src/memory/sqlite_vec_store.rs` file (over 2700 lines) by breaking it down into smaller, more maintainable submodules. 

Key changes:
1. Created a new module directory `src/memory/sqlite_vec_store/`.
2. Moved configuration-related types and constants to `src/memory/sqlite_vec_store/config.rs`.
3. Moved utility functions for tokenization and session management to `src/memory/sqlite_vec_store/utils.rs`.
4. Refactored the main `src/memory/sqlite_vec_store.rs` to delegate to these submodules, significantly reducing its size while preserving all functional logic, including complex transaction management, knowledge graph operations, and specific trait method signatures.

This refactoring improves code maintainability and readability without introducing regressions in the core memory storage and search functionality.

Fixes #337

---
*PR created automatically by Jules for task [1605357910635541555](https://jules.google.com/task/1605357910635541555) started by @iberi22*