### PR TITLE
Fix Websocket Streaming Test Event Race

### DIFF
--- a/benches/cortex.rs
+++ b/benches/cortex.rs
@@ -1,4 +1,4 @@
-﻿use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
 use tokio::runtime::Runtime;
 use xavier::memory::belief_graph::{Belief, BeliefGraph, Confidence};
@@ -19,9 +19,9 @@ fn bench_belief_graph_search(c: &mut Criterion) {
                         Confidence::Medium,
                     ),
                     None,
-                    None,
                 )
-                .await;
+                .await
+                .ok();
         }
     });
 

--- a/benches/hybrid_search.rs
+++ b/benches/hybrid_search.rs
@@ -1,10 +1,10 @@
-﻿use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use sha2::{Digest, Sha256};
 use tempfile::tempdir;
 use tokio::runtime::Runtime;
-use xavier::memory::belief_graph::BeliefRelation;
+use xavier::domain::memory::belief::BeliefEdge;
 use xavier::memory::sqlite_vec_store::{VecSqliteMemoryStore, VecSqliteStoreConfig};
-use xavier::memory::{HybridSearchMode, MemoryRecord, MemoryStore};
+use xavier::memory::{MemoryRecord, MemoryStore};
 
 fn stable_key(kind: &str, parts: &[&str]) -> String {
     let mut digest = Sha256::new();
@@ -78,6 +78,9 @@ fn bench_hybrid_search(c: &mut Criterion) {
                     revision: 1,
                     primary: true,
                     parent_id: None,
+                    cluster_id: None,
+                    level: Default::default(),
+                    relation: None,
                     revisions: Vec::new(),
                 })
                 .await
@@ -88,40 +91,20 @@ fn bench_hybrid_search(c: &mut Criterion) {
             .save_beliefs(
                 workspace_id,
                 vec![
-                    BeliefRelation {
-                        id: ulid::Ulid::new().to_string(),
-                        source: "ACCT-9F3A".to_string(),
-                        target: "Alice Johnson".to_string(),
-                        relation_type: "approved_by".to_string(),
-                        weight: 0.9,
-                        confidence: 0.9,
-                        source_memory_id: Some(stable_key(
-                            "memory",
-                            &[workspace_id, "memory/account-renewal"],
-                        )),
-                        valid_from: None,
-                        valid_until: None,
-                        superseded_by: None,
-                        created_at: chrono::Utc::now(),
-                        updated_at: chrono::Utc::now(),
-                    },
-                    BeliefRelation {
-                        id: ulid::Ulid::new().to_string(),
-                        source: "INC-4821".to_string(),
-                        target: "OpenClaw".to_string(),
-                        relation_type: "handled_by".to_string(),
-                        weight: 0.8,
-                        confidence: 0.8,
-                        source_memory_id: Some(stable_key(
-                            "memory",
-                            &[workspace_id, "memory/incident"],
-                        )),
-                        valid_from: None,
-                        valid_until: None,
-                        superseded_by: None,
-                        created_at: chrono::Utc::now(),
-                        updated_at: chrono::Utc::now(),
-                    },
+                    BeliefEdge::new(
+                        "ACCT-9F3A".to_string(),
+                        "Alice Johnson".to_string(),
+                        "approved_by".to_string(),
+                        0.9,
+                        stable_key("memory", &[workspace_id, "memory/account-renewal"]),
+                    ),
+                    BeliefEdge::new(
+                        "INC-4821".to_string(),
+                        "OpenClaw".to_string(),
+                        "handled_by".to_string(),
+                        0.8,
+                        stable_key("memory", &[workspace_id, "memory/incident"]),
+                    ),
                 ],
             )
             .await
@@ -151,8 +134,7 @@ fn bench_hybrid_search(c: &mut Criterion) {
                 .hybrid_search_with_embedding(
                     workspace_id,
                     query,
-                    HybridSearchMode::Vector,
-                    Some(embedding),
+                    embedding.to_vec(),
                     None,
                     3,
                 )
@@ -169,8 +151,7 @@ fn bench_hybrid_search(c: &mut Criterion) {
                 .hybrid_search_with_embedding(
                     workspace_id,
                     query,
-                    HybridSearchMode::Both,
-                    Some(embedding),
+                    embedding.to_vec(),
                     None,
                     3,
                 )
@@ -203,8 +184,7 @@ fn bench_hybrid_search(c: &mut Criterion) {
                         .hybrid_search_with_embedding(
                             workspace_id,
                             query,
-                            HybridSearchMode::Vector,
-                            Some(embedding),
+                            embedding.to_vec(),
                             None,
                             3,
                         )
@@ -223,8 +203,7 @@ fn bench_hybrid_search(c: &mut Criterion) {
                         .hybrid_search_with_embedding(
                             workspace_id,
                             query,
-                            HybridSearchMode::Both,
-                            Some(embedding),
+                            embedding.to_vec(),
                             None,
                             3,
                         )

--- a/tests/websocket_events.rs
+++ b/tests/websocket_events.rs
@@ -206,20 +206,27 @@ async fn test_websocket_streaming() {
 
     assert_eq!(add_res.status(), StatusCode::OK);
 
-    // Wait for the event
-    let msg = ws_stream
-        .next()
-        .await
-        .expect("test assertion")
-        .expect("test assertion");
-    let event: WsEvent =
-        serde_json::from_str(msg.to_text().expect("test assertion")).expect("test assertion");
+    // Wait for the memory.add event, ignoring others (like timeline_event)
+    let mut found_memory_add = false;
+    // We expect at most a few events (timeline_event, then memory.add)
+    for _ in 0..5 {
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(5), ws_stream.next())
+            .await
+            .expect("timeout waiting for websocket message")
+            .expect("test assertion")
+            .expect("test assertion");
 
-    if let WsEvent::Event(e) = event {
-        assert_eq!(e.agent_id, "test_agent");
-        assert_eq!(e.event_type, "memory.add");
-        assert!(e.payload["path"].as_str().is_some());
-    } else {
-        panic!("Expected WsEvent::Event, got {:?}", event);
+        let event: WsEvent =
+            serde_json::from_str(msg.to_text().expect("test assertion")).expect("test assertion");
+
+        if let WsEvent::Event(e) = event {
+            if e.event_type == "memory.add" {
+                assert_eq!(e.agent_id, "test_agent");
+                assert!(e.payload["path"].as_str().is_some());
+                found_memory_add = true;
+                break;
+            }
+        }
     }
+    assert!(found_memory_add, "Did not receive memory.add event");
 }


### PR DESCRIPTION
Fixed a race condition in the WebSocket streaming integration test where `timeline_event` messages were interleaved with `memory.add` messages, causing assertion failures. The test now robustly filters for the expected event type with a timeout.

Fixes #349

---
*PR created automatically by Jules for task [13464206635554134739](https://jules.google.com/task/13464206635554134739) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved robustness of websocket event handling tests to reliably detect `memory.add` events by polling multiple messages with timeout handling, increasing reliability of event detection assertions.

* **Chores**
  * Updated benchmark files to align with latest memory and belief API structures, ensuring benchmarks remain accurate against current codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/xavier/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->