### PR TITLE
CHORE: Wire or Clean up Enterprise HTTP Routing dead code

### DIFF
--- a/src/adapters/inbound/http/routes.rs
+++ b/src/adapters/inbound/http/routes.rs
@@ -69,9 +69,15 @@ pub fn create_router_with_agent_registry(agent_registry: Arc<dyn AgentLifecycleP
 
     // Add enterprise plugin routes if feature is enabled
     #[cfg(feature = "enterprise")]
-    let router = router
-        .route("/plugins/health", get(plugins_health_handler))
-        .route("/plugins/sync", post(plugins_sync_handler));
+    let router = {
+        let router = router
+            .route("/plugins/health", get(plugins_health_handler))
+            .route("/plugins/sync", post(plugins_sync_handler));
+
+        use crate::enterprise::http::{enterprise_router, EnterpriseState};
+        let enterprise_state = std::sync::Arc::new(std::sync::Mutex::new(EnterpriseState::init_default()));
+        router.merge(enterprise_router(enterprise_state))
+    };
 
     router.with_state(agent_registry)
 }

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -259,8 +259,7 @@ pub async fn start_http_server(port: u16) -> Result<()> {
     println!("Code graph DB: {}", code_db_path.display());
 
     // Build router with state-aware routes
-    #[allow(unused_mut)]
-    let mut protected_routes = Router::new()
+    let protected_routes = Router::new()
         .route("/memory/search", post(search_handler))
         .route("/memory/add", post(add_handler))
         .route("/memory/delete", post(delete_handler))
@@ -330,16 +329,16 @@ pub async fn start_http_server(port: u16) -> Result<()> {
 
     // Add enterprise plugin routes if feature is enabled
     #[cfg(feature = "enterprise")]
-    {
+    let protected_routes = {
         use xavier::adapters::inbound::http::routes::{
             plugins_health_handler, plugins_sync_handler,
         };
-        protected_routes = protected_routes
+        protected_routes
             .route("/plugins/health", get(plugins_health_handler))
-            .route("/plugins/sync", post(plugins_sync_handler));
-    }
+            .route("/plugins/sync", post(plugins_sync_handler))
+    };
 
-    let mut app = Router::new()
+    let app = Router::new()
         .route("/health", get(health_handler))
         .route("/v1/version", get(version_handler))
         .route("/build", get(build_handler))
@@ -352,15 +351,15 @@ pub async fn start_http_server(port: u16) -> Result<()> {
 
     // Merge enterprise HTTP API routes when feature is enabled, under auth
     #[cfg(feature = "enterprise")]
-    {
+    let app = {
         use xavier::enterprise::http::{enterprise_router, EnterpriseState};
         use std::sync::{Arc, Mutex};
         let enterprise_state = Arc::new(Mutex::new(EnterpriseState::init_default()));
-        app = app.merge(
+        app.merge(
             enterprise_router(enterprise_state)
                 .layer(middleware::from_fn(auth_middleware))
-        );
-    }
+        )
+    };
 
     let listener = TcpListener::bind(&bind_addr).await?;
     let bound_addr = listener.local_addr()?;

--- a/src/enterprise/http.rs
+++ b/src/enterprise/http.rs
@@ -3,6 +3,8 @@
 //! Only compiled when the `enterprise` feature is enabled.
 //! Merge with the main router via `Router::merge()`.
 
+#![cfg(feature = "enterprise")]
+
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -192,7 +194,7 @@ impl From<Tenant> for TenantResponse {
 }
 
 /// POST /v1/tenants — Create a new tenant
-async fn create_tenant(
+pub(crate) async fn create_tenant(
     State(state): State<Arc<Mutex<EnterpriseState>>>,
     Json(payload): Json<CreateTenant>,
 ) -> Result<Json<TenantResponse>, EnterpriseError> {
@@ -222,7 +224,7 @@ async fn create_tenant(
 }
 
 /// GET /v1/tenants — List all tenants
-async fn list_tenants(
+pub(crate) async fn list_tenants(
     State(state): State<Arc<Mutex<EnterpriseState>>>,
 ) -> Result<Json<Vec<TenantResponse>>, StatusCode> {
     let state = state.lock().expect("poisoned lock: enterprise_list_tenants");
@@ -237,7 +239,7 @@ async fn list_tenants(
 }
 
 /// GET /v1/tenants/:id — Get a tenant by ID
-async fn get_tenant(
+pub(crate) async fn get_tenant(
     State(state): State<Arc<Mutex<EnterpriseState>>>,
     Path(id): Path<TenantId>,
 ) -> Result<Json<TenantResponse>, EnterpriseError> {
@@ -275,7 +277,7 @@ pub struct ApiKeyResponse {
 }
 
 /// POST /v1/keys — Create a new API key for a tenant
-async fn create_key(
+pub(crate) async fn create_key(
     State(state): State<Arc<Mutex<EnterpriseState>>>,
     Json(payload): Json<CreateKey>,
 ) -> Result<Json<ApiKeyResponse>, EnterpriseError> {
@@ -336,7 +338,7 @@ async fn create_key(
 }
 
 /// GET /v1/keys/:tenant_id — List all API keys for a tenant
-async fn list_keys(
+pub(crate) async fn list_keys(
     State(state): State<Arc<Mutex<EnterpriseState>>>,
     Path(id): Path<TenantId>,
 ) -> Result<Json<Vec<ApiKey>>, StatusCode> {
@@ -351,7 +353,7 @@ async fn list_keys(
 }
 
 /// DELETE /v1/keys/:key_id — Revoke an API key
-async fn revoke_key(
+pub(crate) async fn revoke_key(
     State(state): State<Arc<Mutex<EnterpriseState>>>,
     Path(key_id): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
@@ -395,7 +397,7 @@ async fn revoke_key(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// GET /v1/audit — Query audit log entries
-async fn query_audit(
+pub(crate) async fn query_audit(
     State(state): State<Arc<Mutex<EnterpriseState>>>,
     Query(params): Query<AuditQuery>,
 ) -> Result<Json<Vec<AuditEntry>>, StatusCode> {
@@ -440,7 +442,7 @@ pub struct RateLimitsResponse {
 }
 
 /// GET /v1/rate-limits — Get current rate limit configuration
-async fn get_rate_limits(
+pub(crate) async fn get_rate_limits(
     State(_state): State<Arc<Mutex<EnterpriseState>>>,
 ) -> Result<Json<RateLimitsResponse>, StatusCode> {
     Ok(Json(RateLimitsResponse {
@@ -456,7 +458,7 @@ pub struct UpdateRateLimits {
 }
 
 /// PATCH /v1/rate-limits — Update rate limit configuration
-async fn update_rate_limits(
+pub(crate) async fn update_rate_limits(
     State(state): State<Arc<Mutex<EnterpriseState>>>,
     Json(payload): Json<UpdateRateLimits>,
 ) -> Result<StatusCode, StatusCode> {
@@ -483,7 +485,6 @@ async fn update_rate_limits(
 /// Returns an empty router when `enterprise` feature is disabled.
 ///
 /// Usage: `router.merge(enterprise_router(state))`
-#[cfg(feature = "enterprise")]
 pub fn enterprise_router(state: Arc<Mutex<EnterpriseState>>) -> axum::Router {
     axum::Router::new()
         // Tenant management
@@ -500,10 +501,4 @@ pub fn enterprise_router(state: Arc<Mutex<EnterpriseState>>) -> axum::Router {
         .route("/v1/rate-limits", get(get_rate_limits))
         .route("/v1/rate-limits", patch(update_rate_limits))
         .with_state(state)
-}
-
-/// No-op router when enterprise feature is disabled
-#[cfg(not(feature = "enterprise"))]
-pub fn enterprise_router() -> axum::Router {
-    axum::Router::new()
 }

--- a/src/enterprise/mod.rs
+++ b/src/enterprise/mod.rs
@@ -12,7 +12,14 @@ pub mod rbac;
 pub mod audit;
 pub mod keys;
 pub mod rate_limit;
+#[cfg(feature = "enterprise")]
 pub mod http;
+#[cfg(not(feature = "enterprise"))]
+pub mod http {
+    pub fn enterprise_router() -> axum::Router {
+        axum::Router::new()
+    }
+}
 pub mod persistence;
 #[cfg(test)]
 pub mod tests;


### PR DESCRIPTION
The compiler was emitting several `dead_code` warnings for enterprise HTTP handlers when the `enterprise` feature was disabled. This was because the handlers were implemented but never registered in any active router during non-enterprise builds.

I have addressed this by:
1. Gating the entire `src/enterprise/http.rs` module behind `#![cfg(feature = "enterprise")]`.
2. Implementing a no-op version of the `enterprise_router` function in `src/enterprise/mod.rs` when the feature is disabled, ensuring that code referencing it still compiles.
3. Wiring the actual enterprise router into the production routing table in `src/adapters/inbound/http/routes.rs`, making the handlers "live" and eliminating the dead code warning even when the feature is enabled.
4. Refactoring `src/cli/server.rs` to eliminate `unused_mut` warnings that occurred when the enterprise feature (which was the only thing mutating the router) was disabled.

All existing enterprise unit tests and HTTP integration tests pass successfully.

Fixes #350

---
*PR created automatically by Jules for task [7471637611923035131](https://jules.google.com/task/7471637611923035131) started by @iberi22*