### PR TITLE
Integrate validate_grounding() into retrieval pipeline

### DIFF
--- a/src/context/orchestrator.rs
+++ b/src/context/orchestrator.rs
@@ -129,9 +129,38 @@ impl Orchestrator {
         // 2. Probabilistic Retrieval (Hybrid Search) - Fill remaining budget
         let remaining_limit = config.max_documents.saturating_sub(selected_document_ids.len());
         if remaining_limit > 0 {
-            let hybrid_hits = self
+            let mut hybrid_hits = self
                 .search
                 .search(&session_documents, &query, remaining_limit);
+
+            // Integrate Grounding Validation for Hybrid Search
+            if let Some(graph_lock) = &self.belief_graph {
+                let graph = graph_lock.read().await;
+                let docs_to_validate: Vec<_> = hybrid_hits
+                    .iter()
+                    .map(|hit| crate::memory::qmd_memory::MemoryDocument {
+                        id: Some(hit.document.id.clone()),
+                        content: hit.document.content.clone(),
+                        path: hit.document.metadata["path"]
+                            .as_str()
+                            .unwrap_or("unknown")
+                            .to_string(),
+                        ..Default::default()
+                    })
+                    .collect();
+
+                // Use default threshold 0.5 for now, could be made configurable in Orchestrator
+                let grounding = graph.validate_grounding(&docs_to_validate, 0.5).await;
+
+                hybrid_hits.retain(|hit| {
+                    grounding
+                        .iter()
+                        .find(|(id, _, _)| id == &hit.document.id)
+                        .map(|(_, grounded, _)| *grounded)
+                        .unwrap_or(false)
+                });
+            }
+
             for hit in hybrid_hits {
                 if !selected_document_ids.contains(&hit.document.id) {
                     selected_document_ids.push(hit.document.id);

--- a/src/memory/belief_graph.rs
+++ b/src/memory/belief_graph.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, RwLock};
 use tokio::sync::RwLock as AsyncRwLock;
 use tracing::info;
+use aho_corasick::AhoCorasick;
 use chrono::Utc;
 
 use crate::domain::memory::belief::{BeliefEdge, BeliefNode};
@@ -357,10 +358,30 @@ impl BeliefGraph {
 
     /// Validates if a list of documents are grounded in the belief graph.
     /// Returns a list of (memory_id, is_grounded, explanation)
-    pub async fn validate_grounding(&self, documents: &[crate::memory::qmd_memory::MemoryDocument]) -> Vec<(String, bool, String)> {
+    pub async fn validate_grounding(
+        &self,
+        documents: &[crate::memory::qmd_memory::MemoryDocument],
+        min_confidence: f32,
+    ) -> Vec<(String, bool, String)> {
         let mut results = Vec::new();
         let edges = self.get_edges();
-        let nodes = self.list_nodes(); // Hoisted outside loop: O(N) once, not O(D*N)
+        let nodes = self.list_nodes();
+
+        // Performance Optimization: Filter eligible nodes and build Aho-Corasick automaton
+        let eligible_nodes: Vec<_> = nodes
+            .into_iter()
+            .filter(|n| n.confidence >= min_confidence)
+            .collect();
+
+        let ac = if !eligible_nodes.is_empty() {
+            let patterns: Vec<String> = eligible_nodes
+                .iter()
+                .map(|n| n.concept.to_lowercase())
+                .collect();
+            AhoCorasick::new(patterns).ok()
+        } else {
+            None
+        };
 
         for doc in documents {
             let memory_id = doc.id.clone().unwrap_or_else(|| doc.path.clone());
@@ -369,28 +390,36 @@ impl BeliefGraph {
             let has_belief = edges.iter().any(|e| e.provenance_id == memory_id);
 
             if has_belief {
-                results.push((memory_id, true, "Directly grounded in belief graph".to_string()));
-                continue;
-            }
-
-            // Semantic grounding: check if key terms in content match established nodes
-            let content_lower = doc.content.to_lowercase();
-            let matching_nodes: Vec<_> = nodes.iter()
-                .filter(|n| content_lower.contains(&n.concept.to_lowercase()))
-                .collect();
-
-            if !matching_nodes.is_empty() {
-                let node_names: Vec<_> = matching_nodes.iter().map(|n| &n.concept).collect();
                 results.push((
                     memory_id,
                     true,
-                    format!("Semantically grounded through concepts: {:?}", node_names)
+                    "Directly grounded in belief graph".to_string(),
+                ));
+                continue;
+            }
+
+            // Semantic grounding: check if key terms in content match established nodes above threshold
+            let mut matched_concepts = HashSet::new();
+            if let Some(ref ac_idx) = ac {
+                let content_lower = doc.content.to_lowercase();
+                for mat in ac_idx.find_iter(&content_lower) {
+                    matched_concepts.insert(eligible_nodes[mat.pattern().as_usize()].concept.clone());
+                }
+            }
+
+            if !matched_concepts.is_empty() {
+                let mut node_names: Vec<_> = matched_concepts.into_iter().collect();
+                node_names.sort();
+                results.push((
+                    memory_id,
+                    true,
+                    format!("Semantically grounded through concepts: {:?}", node_names),
                 ));
             } else {
                 results.push((
                     memory_id,
                     false,
-                    "No supporting beliefs or nodes found in graph".to_string()
+                    "No supporting beliefs or nodes found in graph".to_string(),
                 ));
             }
         }
@@ -406,3 +435,83 @@ impl Default for BeliefGraph {
 }
 
 pub type SharedBeliefGraph = Arc<AsyncRwLock<BeliefGraph>>;
+
+#[cfg(test)]
+mod grounding_tests {
+    use super::*;
+    use crate::memory::qmd_memory::MemoryDocument;
+
+    #[tokio::test]
+    async fn test_validate_grounding_direct() {
+        let graph = BeliefGraph::new();
+        let memory_id = "mem-1".to_string();
+
+        // Add a relation with provenance_id
+        graph.add_relation(
+            "Xavier".to_string(),
+            "Memory".to_string(),
+            "is_a".to_string(),
+            Some(memory_id.clone()),
+            None
+        ).await.unwrap();
+
+        let docs = vec![
+            MemoryDocument {
+                id: Some(memory_id.clone()),
+                content: "Something about Xavier".to_string(),
+                ..Default::default()
+            }
+        ];
+
+        let results = graph.validate_grounding(&docs, 0.5).await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, memory_id);
+        assert_eq!(results[0].1, true);
+        assert!(results[0].2.contains("Directly grounded"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_grounding_semantic() {
+        let graph = BeliefGraph::new();
+        graph.add_node("Xavier".to_string(), 0.9);
+        graph.add_node("Rust".to_string(), 0.4);
+
+        let docs = vec![
+            MemoryDocument {
+                id: Some("doc-1".to_string()),
+                content: "Xavier is written in Rust".to_string(),
+                ..Default::default()
+            }
+        ];
+
+        // With min_confidence 0.5, only "Xavier" should match
+        let results = graph.validate_grounding(&docs, 0.5).await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, true);
+        assert!(results[0].2.contains("Xavier"));
+        assert!(!results[0].2.contains("Rust"));
+
+        // With min_confidence 0.3, both should match
+        let results = graph.validate_grounding(&docs, 0.3).await;
+        assert!(results[0].2.contains("Xavier"));
+        assert!(results[0].2.contains("Rust"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_grounding_no_match() {
+        let graph = BeliefGraph::new();
+        graph.add_node("Xavier".to_string(), 0.9);
+
+        let docs = vec![
+            MemoryDocument {
+                id: Some("doc-1".to_string()),
+                content: "Something unrelated".to_string(),
+                ..Default::default()
+            }
+        ];
+
+        let results = graph.validate_grounding(&docs, 0.5).await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, false);
+    }
+}

--- a/src/retrieval/gating.rs
+++ b/src/retrieval/gating.rs
@@ -72,6 +72,10 @@ pub struct GatingConfig {
     pub max_results: usize,
     /// Targeted zones for the retrieval
     pub active_zones: Option<Vec<ContextZone>>,
+    /// Whether to enable belief graph grounding validation
+    pub grounding_enabled: bool,
+    /// Minimum confidence for semantic grounding
+    pub grounding_min_confidence: f32,
 }
 
 impl Default for GatingConfig {
@@ -82,6 +86,8 @@ impl Default for GatingConfig {
             rrf_k: config::DEFAULT_RRF_K,
             max_results: config::DEFAULT_MAX_RESULTS,
             active_zones: None,
+            grounding_enabled: true,
+            grounding_min_confidence: 0.5,
         }
     }
 }
@@ -112,12 +118,13 @@ impl AdaptiveGating {
     }
 
     /// Retrieve from all memory layers and fuse results
-    pub fn retrieve(
+    pub async fn retrieve(
         &self,
         working: &[MemoryDocument],
         episodic: &[SessionSummary],
         semantic: &[EntityRecord],
         query: &str,
+        belief_graph: Option<crate::memory::belief_graph::SharedBeliefGraph>,
     ) -> Vec<ScoredResult> {
         // 1. Score each layer independently
         let working_results = self.score_working_layer(working, query);
@@ -138,12 +145,44 @@ impl AdaptiveGating {
             self.config.rrf_k,
         );
 
-        // 4. Filter by threshold and limit results
-        fused
+        // 4. Filter by threshold
+        let mut results: Vec<ScoredResult> = fused
             .into_iter()
             .filter(|r| r.score >= self.config.relevance_threshold)
-            .take(self.config.max_results)
-            .collect()
+            .collect();
+
+        // 5. Apply grounding validation if enabled
+        if self.config.grounding_enabled {
+            if let Some(graph_lock) = belief_graph {
+                let graph = graph_lock.read().await;
+                // Convert ScoredResult back to MemoryDocument for validate_grounding
+                // Note: We only have content/id, so we build partial documents
+                let docs_to_validate: Vec<MemoryDocument> = results
+                    .iter()
+                    .map(|r| MemoryDocument {
+                        id: Some(r.id.clone()),
+                        content: r.content.clone(),
+                        path: r.path.clone(),
+                        ..Default::default()
+                    })
+                    .collect();
+
+                let grounding = graph
+                    .validate_grounding(&docs_to_validate, self.config.grounding_min_confidence)
+                    .await;
+
+                results.retain(|r| {
+                    grounding
+                        .iter()
+                        .find(|(id, _, _)| id == &r.id)
+                        .map(|(_, grounded, _)| *grounded)
+                        .unwrap_or(false)
+                });
+            }
+        }
+
+        // 6. Limit results
+        results.into_iter().take(self.config.max_results).collect()
     }
 
     /// Retrieve only from working memory
@@ -522,8 +561,8 @@ mod tests {
         assert_eq!(results[0].score, 0.5);
     }
 
-    #[test]
-    fn test_multi_layer_retrieval() {
+    #[tokio::test]
+    async fn test_multi_layer_retrieval() {
         let mut gating = AdaptiveGating::with_defaults();
         gating.set_threshold(0.0);
         let docs = vec![MemoryDocument {
@@ -538,7 +577,7 @@ mod tests {
         let sessions: Vec<SessionSummary> = vec![];
         let entities: Vec<EntityRecord> = vec![];
 
-        let results = gating.retrieve(&docs, &sessions, &entities, "BELA");
+        let results = gating.retrieve(&docs, &sessions, &entities, "BELA", None).await;
         assert!(!results.is_empty());
         assert_eq!(results[0].source, "hybrid");
     }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -516,6 +516,20 @@ pub struct MultiLayerRetrieveRequest {
     /// Include coherence report
     #[serde(default)]
     pub include_coherence: bool,
+    /// Whether to enable belief graph grounding validation
+    #[serde(default = "default_true")]
+    pub grounding_enabled: bool,
+    /// Minimum confidence for semantic grounding
+    #[serde(default = "default_grounding_threshold")]
+    pub grounding_min_confidence: f32,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_grounding_threshold() -> f32 {
+    0.5
 }
 
 fn default_relevance_threshold() -> f32 {
@@ -1088,6 +1102,8 @@ async fn build_multi_layer_retrieve_response(
         rrf_k: payload.rrf_k,
         max_results: payload.limit.max(1),
         active_zones: None,
+        grounding_enabled: payload.grounding_enabled,
+        grounding_min_confidence: payload.grounding_min_confidence,
     });
 
     let working_docs = workspace.workspace.memory.all_documents().await;
@@ -1113,12 +1129,15 @@ async fn build_multi_layer_retrieve_response(
         workspace.workspace.entity_graph.all_entities().await;
     let semantic_count = semantic_entities.len();
 
-    let results = gating.retrieve(
-        &working_docs,
-        &episodic_summaries,
-        &semantic_entities,
-        &payload.query,
-    );
+    let results = gating
+        .retrieve(
+            &working_docs,
+            &episodic_summaries,
+            &semantic_entities,
+            &payload.query,
+            Some(Arc::clone(&workspace.workspace.belief_graph)),
+        )
+        .await;
 
     let total_results = results.len();
 
@@ -1131,7 +1150,6 @@ async fn build_multi_layer_retrieve_response(
 
     let retrieved: Vec<RetrievedMemory> = results
         .into_iter()
-        .take(payload.limit)
         .map(|r| {
             let crate::search::rrf::ScoredResult {
                 id,


### PR DESCRIPTION
Integrated the existing `validate_grounding()` function from `BeliefGraph` into the retrieval pipeline to filter hallucinations.

Key changes:
1.  **src/memory/belief_graph.rs**: 
    - Added `min_confidence: f32` parameter to `validate_grounding`.
    - Implemented performance optimization using `aho-corasick` for semantic concept matching, replacing the previous O(D * N) substring search.
2.  **src/retrieval/gating.rs**:
    - Expanded `GatingConfig` with `grounding_enabled` and `grounding_min_confidence`.
    - Made `AdaptiveGating::retrieve` asynchronous and integrated grounding validation after RRF fusion.
3.  **src/context/orchestrator.rs**:
    - Integrated grounding validation in the `plan` method for hybrid search hits, ensuring probabilistic results are backed by the belief graph.
4.  **src/server/http.rs**:
    - Added `grounding_enabled` and `grounding_min_confidence` to the `MultiLayerRetrieveRequest` payload.
    - Updated the handler to pass the workspace's belief graph to the gating logic.

This integration ensures that retrieved context is grounded in established beliefs or provenance, reducing the risk of including hallucinated information in the reasoning context.

Fixes #363

---
*PR created automatically by Jules for task [7954571881427153318](https://jules.google.com/task/7954571881427153318) started by @iberi22*