### PR TITLE
Make zone boost/penalty multipliers configurable

### DIFF
--- a/src/retrieval/config.rs
+++ b/src/retrieval/config.rs
@@ -35,3 +35,20 @@ pub const ENTITY_DESCRIPTION_MATCH_SCORE: f32 = 0.4;
 pub const ENTITY_DESCRIPTION_TERM_BONUS: f32 = 0.1;
 pub const ENTITY_ALIAS_MATCH_SCORE: f32 = 0.6;
 pub const SEMANTIC_CONFIDENCE_MULTIPLIER: f32 = 0.5;
+
+pub const DEFAULT_ZONE_BOOST_MULTIPLIER: f32 = 1.5;
+pub const DEFAULT_ZONE_PENALTY_MULTIPLIER: f32 = 0.5;
+
+pub fn configured_zone_boost() -> f32 {
+    std::env::var("XAVIER_ZONE_BOOST")
+        .ok()
+        .and_then(|value| value.parse::<f32>().ok())
+        .unwrap_or(DEFAULT_ZONE_BOOST_MULTIPLIER)
+}
+
+pub fn configured_zone_penalty() -> f32 {
+    std::env::var("XAVIER_ZONE_PENALTY")
+        .ok()
+        .and_then(|value| value.parse::<f32>().ok())
+        .unwrap_or(DEFAULT_ZONE_PENALTY_MULTIPLIER)
+}

--- a/src/retrieval/gating.rs
+++ b/src/retrieval/gating.rs
@@ -72,6 +72,10 @@ pub struct GatingConfig {
     pub max_results: usize,
     /// Targeted zones for the retrieval
     pub active_zones: Option<Vec<ContextZone>>,
+    /// Multiplier for targeted zones (default 1.5)
+    pub zone_boost_multiplier: f32,
+    /// Multiplier for non-targeted zones (default 0.5)
+    pub zone_penalty_multiplier: f32,
 }
 
 impl Default for GatingConfig {
@@ -82,6 +86,8 @@ impl Default for GatingConfig {
             rrf_k: config::DEFAULT_RRF_K,
             max_results: config::DEFAULT_MAX_RESULTS,
             active_zones: None,
+            zone_boost_multiplier: config::configured_zone_boost(),
+            zone_penalty_multiplier: config::configured_zone_penalty(),
         }
     }
 }
@@ -199,9 +205,9 @@ impl AdaptiveGating {
                     // Apply zone-based boosting
                     if let Some(active) = &self.config.active_zones {
                         if active.contains(&doc_zone) {
-                            final_score *= 1.5; // Boost targeted zones
+                            final_score *= self.config.zone_boost_multiplier; // Boost targeted zones
                         } else {
-                            final_score *= 0.5; // Penalize non-targeted zones
+                            final_score *= self.config.zone_penalty_multiplier; // Penalize non-targeted zones
                         }
                     }
 
@@ -541,5 +547,49 @@ mod tests {
         let results = gating.retrieve(&docs, &sessions, &entities, "BELA");
         assert!(!results.is_empty());
         assert_eq!(results[0].source, "hybrid");
+    }
+
+    #[test]
+    fn test_zone_multipliers() {
+        let mut config = GatingConfig::default();
+        config.zone_boost_multiplier = 2.0;
+        config.zone_penalty_multiplier = 0.1;
+        config.active_zones = Some(vec![ContextZone::Global]);
+
+        let gating = AdaptiveGating::new(config);
+
+        let docs = vec![
+            MemoryDocument {
+                id: Some("doc1".to_string()),
+                path: "test1".to_string(),
+                content: "search term".to_string(),
+                metadata: serde_json::json!({"zone": "global"}),
+                ..Default::default()
+            },
+            MemoryDocument {
+                id: Some("doc2".to_string()),
+                path: "test2".to_string(),
+                content: "search term".to_string(),
+                metadata: serde_json::json!({"zone": "atomic"}),
+                ..Default::default()
+            },
+        ];
+
+        let results = gating.score_working_layer(&docs, "search term");
+
+        assert_eq!(results.len(), 2);
+
+        let res1 = results.iter().find(|r| r.id == "doc1").unwrap();
+        let res2 = results.iter().find(|r| r.id == "doc2").unwrap();
+
+        // Base score for "search term" (two terms)
+        // EXACT_PHRASE_MATCH_BONUS = 0.5
+        // TERM_MATCH_BONUS = 0.1 (x2)
+        // TERM_OCCURRENCE_BONUS = 0.05 (x2)
+        // Total base score = 0.5 + 0.2 + 0.1 = 0.8
+        // doc1 (boost 2.0): 0.8 * 2.0 = 1.6
+        // doc2 (penalty 0.1): 0.8 * 0.1 = 0.08
+        assert!((res1.score - 1.6).abs() < 0.001);
+        assert!((res2.score - 0.08).abs() < 0.001);
     }
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -1081,6 +1081,7 @@ async fn build_multi_layer_retrieve_response(
     payload: &MultiLayerRetrieveRequest,
 ) -> MultiLayerRetrieveResponse {
     let weights = payload.layer_weights.unwrap_or_default();
+    let settings = crate::settings::XavierSettings::current();
 
     let gating = AdaptiveGating::new(crate::retrieval::gating::GatingConfig {
         layer_weights: weights,
@@ -1088,6 +1089,14 @@ async fn build_multi_layer_retrieve_response(
         rrf_k: payload.rrf_k,
         max_results: payload.limit.max(1),
         active_zones: None,
+        zone_boost_multiplier: settings
+            .retrieval
+            .zone_boost_multiplier
+            .unwrap_or_else(crate::retrieval::config::configured_zone_boost),
+        zone_penalty_multiplier: settings
+            .retrieval
+            .zone_penalty_multiplier
+            .unwrap_or_else(crate::retrieval::config::configured_zone_penalty),
     });
 
     let working_docs = workspace.workspace.memory.all_documents().await;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -273,11 +273,17 @@ impl Default for ModelSettings {
 #[derive(Debug, Clone, Deserialize)]
 pub struct RetrievalSettings {
     pub disable_hyde: bool,
+    pub zone_boost_multiplier: Option<f32>,
+    pub zone_penalty_multiplier: Option<f32>,
 }
 
 impl Default for RetrievalSettings {
     fn default() -> Self {
-        Self { disable_hyde: true }
+        Self {
+            disable_hyde: true,
+            zone_boost_multiplier: None,
+            zone_penalty_multiplier: None,
+        }
     }
 }
 
@@ -636,6 +642,14 @@ impl XavierSettings {
                 "0"
             },
         );
+        set_optional_if_absent(
+            "XAVIER_ZONE_BOOST",
+            self.retrieval.zone_boost_multiplier.map(|v| v.to_string()),
+        );
+        set_optional_if_absent(
+            "XAVIER_ZONE_PENALTY",
+            self.retrieval.zone_penalty_multiplier.map(|v| v.to_string()),
+        );
 
         set_if_absent(
             "XAVIER_SYNC_INTERVAL_MS",
@@ -749,6 +763,16 @@ impl XavierSettings {
         }
         if settings.embedding.api_key.is_none() {
             settings.embedding.api_key = std::env::var("XAVIER_EMBEDDING_API_KEY").ok();
+        }
+        if settings.retrieval.zone_boost_multiplier.is_none() {
+            settings.retrieval.zone_boost_multiplier = std::env::var("XAVIER_ZONE_BOOST")
+                .ok()
+                .and_then(|v| v.parse().ok());
+        }
+        if settings.retrieval.zone_penalty_multiplier.is_none() {
+            settings.retrieval.zone_penalty_multiplier = std::env::var("XAVIER_ZONE_PENALTY")
+                .ok()
+                .and_then(|v| v.parse().ok());
         }
         settings
     }


### PR DESCRIPTION
This change makes the zone boost and penalty multipliers configurable via `XavierSettings` or environment variables (`XAVIER_ZONE_BOOST` and `XAVIER_ZONE_PENALTY`). 

Previously, these values were hardcoded as 1.5x for targeted zones and 0.5x for non-targeted zones in `src/retrieval/gating.rs`. The implementation now:
1. Defines default constants and environment retrieval helpers in `src/retrieval/config.rs`.
2. Extends `RetrievalSettings` in `src/settings.rs` to support these new configuration options, including environment variable mapping in `apply_to_env` and `current`.
3. Updates `GatingConfig` in `src/retrieval/gating.rs` to hold these multipliers, defaulting to the values from the environment or the original hardcoded constants.
4. Modifies the `score_working_layer` method in `src/retrieval/gating.rs` to use these configurable multipliers.
5. Ensures that the HTTP handler for multi-layer retrieval in `src/server/http.rs` correctly applies these settings.
6. Includes a new test case in `src/retrieval/gating.rs` to verify that custom multipliers are correctly applied to the final scores.

The change is fully backward compatible as it preserves the original 1.5/0.5 values as defaults.

Fixes #365

---
*PR created automatically by Jules for task [9926574445030096218](https://jules.google.com/task/9926574445030096218) started by @iberi22*