### PR TITLE
perf: Implement cross-encoder re-ranking after RRF fusion

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -58,14 +58,12 @@ pub async fn hybrid_search(
     Extension(workspace): Extension<WorkspaceContext>,
     Json(request): Json<HybridSearchRequest>,
 ) -> impl IntoResponse {
-    let searcher = HybridSearcher {
-        keyword_weight: request.keyword_weight,
-        vector_weight: request.vector_weight,
-        rrf_k: request
-            .rrf_k
-            .unwrap_or_else(crate::search::hybrid::configured_rrf_k),
-        hooks: crate::search::hooks::HookRegistry::new(),
-    };
+    let mut searcher = HybridSearcher::new();
+    searcher.keyword_weight = request.keyword_weight;
+    searcher.vector_weight = request.vector_weight;
+    if let Some(rrf_k) = request.rrf_k {
+        searcher.rrf_k = rrf_k;
+    }
 
     let results = searcher
         .search(

--- a/src/retrieval/config.rs
+++ b/src/retrieval/config.rs
@@ -15,6 +15,7 @@ pub fn configured_rrf_k() -> u32 {
 
 pub const DEFAULT_MAX_RESULTS: usize = 20;
 pub const DEFAULT_SEARCH_LIMIT: usize = 10;
+pub const DEFAULT_RERANK_LIMIT: usize = 50;
 pub const DEFAULT_KEYWORD_WEIGHT: f32 = 0.5;
 pub const DEFAULT_VECTOR_WEIGHT: f32 = 0.5;
 

--- a/src/retrieval/gating.rs
+++ b/src/retrieval/gating.rs
@@ -112,7 +112,7 @@ impl AdaptiveGating {
     }
 
     /// Retrieve from all memory layers and fuse results
-    pub fn retrieve(
+    pub async fn retrieve(
         &self,
         working: &[MemoryDocument],
         episodic: &[SessionSummary],
@@ -133,12 +133,26 @@ impl AdaptiveGating {
             self.apply_weights(semantic_results, self.config.layer_weights.semantic);
 
         // 3. Fuse with RRF
-        let fused = reciprocal_rank_fusion(
+        let mut fused = reciprocal_rank_fusion(
             vec![weighted_working, weighted_episodic, weighted_semantic],
             self.config.rrf_k,
         );
 
-        // 4. Filter by threshold and limit results
+        // 4. Optional Reranking for precision boost
+        if let Some(hook) = crate::search::rerank::RerankHook::from_env() {
+            let rerank_limit = crate::retrieval::config::DEFAULT_RERANK_LIMIT;
+            if fused.len() > rerank_limit {
+                fused.truncate(rerank_limit);
+            }
+
+            let _ = crate::search::hooks::SearchHook::post_query(
+                &hook,
+                query,
+                &mut fused,
+            ).await;
+        }
+
+        // 5. Filter by threshold and limit results
         fused
             .into_iter()
             .filter(|r| r.score >= self.config.relevance_threshold)
@@ -522,8 +536,8 @@ mod tests {
         assert_eq!(results[0].score, 0.5);
     }
 
-    #[test]
-    fn test_multi_layer_retrieval() {
+    #[tokio::test]
+    async fn test_multi_layer_retrieval() {
         let mut gating = AdaptiveGating::with_defaults();
         gating.set_threshold(0.0);
         let docs = vec![MemoryDocument {
@@ -538,7 +552,7 @@ mod tests {
         let sessions: Vec<SessionSummary> = vec![];
         let entities: Vec<EntityRecord> = vec![];
 
-        let results = gating.retrieve(&docs, &sessions, &entities, "BELA");
+        let results = gating.retrieve(&docs, &sessions, &entities, "BELA").await;
         assert!(!results.is_empty());
         assert_eq!(results[0].source, "hybrid");
     }

--- a/src/search/hybrid.rs
+++ b/src/search/hybrid.rs
@@ -29,11 +29,16 @@ pub struct HybridSearcher {
 
 impl Default for HybridSearcher {
     fn default() -> Self {
+        let mut hooks = HookRegistry::new();
+        if let Some(rerank_hook) = crate::search::rerank::RerankHook::from_env() {
+            hooks.add_hook(std::sync::Arc::new(rerank_hook));
+        }
+
         Self {
             keyword_weight: 0.5,
             vector_weight: 0.5,
             rrf_k: configured_rrf_k(),
-            hooks: HookRegistry::new(),
+            hooks,
         }
     }
 }
@@ -63,11 +68,14 @@ impl HybridSearcher {
             .await
             .map_err(|e| SearchError::Hook(e.to_string()))?;
 
+        // Use a larger candidate pool if reranking is likely to be involved
+        let candidate_limit = if self.hooks.len() > 0 { limit * 3 } else { limit * 2 };
+
         let keyword_results = self
-            .keyword_search(memory, &query, limit * 2, filters.as_ref())
+            .keyword_search(memory, &query, candidate_limit, filters.as_ref())
             .await?;
         let vector_results = self
-            .vector_search(memory, &query, limit * 2, filters.as_ref())
+            .vector_search(memory, &query, candidate_limit, filters.as_ref())
             .await
             .unwrap_or_default();
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,4 +1,5 @@
 pub mod bm25;
 pub mod hooks;
 pub mod hybrid;
+pub mod rerank;
 pub mod rrf;

--- a/src/search/rerank.rs
+++ b/src/search/rerank.rs
@@ -1,0 +1,192 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use super::rrf::ScoredResult;
+use crate::search::hooks::SearchHook;
+use crate::memory::schema::MemoryQueryFilters;
+
+#[async_trait]
+pub trait Reranker: Send + Sync {
+    async fn rerank(&self, query: &str, results: &mut Vec<ScoredResult>) -> anyhow::Result<()>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RerankRequest {
+    model: String,
+    query: String,
+    documents: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_n: Option<usize>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RerankResponse {
+    results: Vec<RerankResult>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RerankResult {
+    index: usize,
+    relevance_score: f32,
+}
+
+pub struct HttpReranker {
+    endpoint: String,
+    model: String,
+    api_key: Option<String>,
+}
+
+impl HttpReranker {
+    pub fn new(endpoint: String, model: String, api_key: Option<String>) -> Self {
+        Self {
+            endpoint,
+            model,
+            api_key,
+        }
+    }
+
+    pub fn from_env() -> Option<Self> {
+        let enabled = std::env::var("XAVIER_RERANK_ENABLED")
+            .map(|v| v.to_lowercase() == "true")
+            .unwrap_or(false);
+
+        if !enabled {
+            return None;
+        }
+
+        let endpoint = std::env::var("XAVIER_RERANK_ENDPOINT")
+            .unwrap_or_else(|_| "http://localhost:11434/v1/rerank".to_string());
+        let model = std::env::var("XAVIER_RERANK_MODEL")
+            .unwrap_or_else(|_| "mxbai-rerank-base".to_string());
+        let api_key = std::env::var("XAVIER_RERANK_API_KEY").ok();
+
+        Some(Self::new(endpoint, model, api_key))
+    }
+}
+
+#[async_trait]
+impl Reranker for HttpReranker {
+    async fn rerank(&self, query: &str, results: &mut Vec<ScoredResult>) -> anyhow::Result<()> {
+        if results.is_empty() {
+            return Ok(());
+        }
+
+        let documents: Vec<String> = results.iter().map(|r| r.content.clone()).collect();
+        let top_n = results.len();
+
+        let request = RerankRequest {
+            model: self.model.clone(),
+            query: query.to_string(),
+            documents,
+            top_n: Some(top_n),
+        };
+
+        let client = &crate::utils::http::DEFAULT_HTTP_CLIENT;
+        let mut req = client.post(&self.endpoint).json(&request);
+        if let Some(key) = &self.api_key {
+            req = req.header("Authorization", format!("Bearer {key}"));
+        }
+
+        let response: RerankResponse = req.send().await?.json().await?;
+
+        // Re-score results based on reranker output
+        let mut index_to_score = std::collections::HashMap::new();
+        for res in response.results {
+            index_to_score.insert(res.index, res.relevance_score);
+        }
+
+        for (i, result) in results.iter_mut().enumerate() {
+            if let Some(score) = index_to_score.get(&i) {
+                result.score = *score;
+            }
+        }
+
+        // Sort by new score
+        results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockReranker;
+    #[async_trait]
+    impl Reranker for MockReranker {
+        async fn rerank(&self, _query: &str, results: &mut Vec<ScoredResult>) -> anyhow::Result<()> {
+            // Reverse scores for testing
+            let len = results.len();
+            for (i, res) in results.iter_mut().enumerate() {
+                res.score = (len - i) as f32;
+            }
+            results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rerank_hook() {
+        let hook = RerankHook::new(Arc::new(MockReranker));
+        let mut results = vec![
+            ScoredResult {
+                id: "1".into(),
+                content: "doc1".into(),
+                score: 0.1,
+                source: "test".into(),
+                path: "path1".into(),
+                updated_at: None,
+            },
+            ScoredResult {
+                id: "2".into(),
+                content: "doc2".into(),
+                score: 0.9,
+                source: "test".into(),
+                path: "path2".into(),
+                updated_at: None,
+            },
+        ];
+
+        hook.post_query("query", &mut results).await.unwrap();
+
+        assert_eq!(results[0].id, "1");
+        assert_eq!(results[0].score, 2.0);
+        assert_eq!(results[1].id, "2");
+        assert_eq!(results[1].score, 1.0);
+    }
+}
+
+pub struct RerankHook {
+    reranker: Arc<dyn Reranker>,
+}
+
+impl RerankHook {
+    pub fn new(reranker: Arc<dyn Reranker>) -> Self {
+        Self { reranker }
+    }
+
+    pub fn from_env() -> Option<Self> {
+        HttpReranker::from_env().map(|r| Self::new(Arc::new(r)))
+    }
+}
+
+#[async_trait]
+impl SearchHook for RerankHook {
+    fn name(&self) -> &str {
+        "rerank"
+    }
+
+    async fn post_query(&self, query: &str, results: &mut Vec<ScoredResult>) -> anyhow::Result<()> {
+        self.reranker.rerank(query, results).await
+    }
+
+    async fn pre_query(
+        &self,
+        _query: &mut String,
+        _filters: &mut Option<MemoryQueryFilters>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -1118,7 +1118,7 @@ async fn build_multi_layer_retrieve_response(
         &episodic_summaries,
         &semantic_entities,
         &payload.query,
-    );
+    ).await;
 
     let total_results = results.len();
 


### PR DESCRIPTION
This PR introduces a cross-encoder re-ranking step to the search pipeline to improve precision. After RRF fusion (BM25 + vector), candidates are optionally re-ordered using a model like `mxbai-rerank-base`. 

Key changes:
- New `src/search/rerank.rs` with `Reranker` trait and `HttpReranker` implementation.
- `RerankHook` enables pluggable reranking via the existing hook system.
- `HybridSearcher` and `AdaptiveGating` now support post-fusion reranking.
- Retrieval pipeline is now asynchronous to handle network calls during reranking.
- Configurable via `XAVIER_RERANK_ENABLED`, `XAVIER_RERANK_ENDPOINT`, etc.

Fixes #357

---
*PR created automatically by Jules for task [15962427632345829408](https://jules.google.com/task/15962427632345829408) started by @iberi22*