### PR TITLE
Wire active_zones to HTTP search/retrieve API endpoints

### DIFF
--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -41,8 +41,7 @@ use xavier::coordination::SimpleAgentRegistry;
 use xavier::coordination::{KeyLendingEngine, XavierEventBus};
 use xavier::memory::qmd_memory::{MemoryDocument, QmdMemory};
 use xavier::app::security_service::SecurityService as AppSecurityService;
-use xavier::memory::schema::MemoryLevel;
-use xavier::memory::schema::MemoryQueryFilters;
+use xavier::memory::schema::{ContextZone, MemoryLevel, MemoryQueryFilters};
 use xavier::memory::session_store::{PanelMessage, SessionStore};
 use xavier::memory::sqlite_vec_store::{VecSqliteMemoryStore, VecSqliteStoreConfig};
 use xavier::memory::store::{MemoryRecord, MemoryStore};
@@ -917,7 +916,13 @@ pub async fn search_handler(
     let limit = payload.limit.clamp(1, 100);
     info!("Search request: query={}, limit={}", effective_query, limit);
 
-    let filters = payload.filters.clone().unwrap_or_default();
+    let mut filters = payload.filters.clone().unwrap_or_default();
+    let zones = payload
+        .active_zones
+        .clone()
+        .unwrap_or_else(|| xavier::memory::schema::parse_zones_from_prompt(effective_query));
+    filters.zones = Some(zones);
+
     let results: Vec<MemoryRecord> = match state.memory.search(effective_query, Some(filters)).await {
         Ok(results) => results,
         Err(e) => {
@@ -2280,6 +2285,8 @@ pub(crate) struct SearchPayload {
     limit: usize,
     #[serde(default, rename = "filters")]
     filters: Option<MemoryQueryFilters>,
+    #[serde(default)]
+    active_zones: Option<Vec<ContextZone>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/context/orchestrator.rs
+++ b/src/context/orchestrator.rs
@@ -101,7 +101,7 @@ impl Orchestrator {
         documents: &[ContextDocument],
     ) -> ExecutionPlan {
         let level = self.classifier.classify(prompt);
-        let active_zones = parse_zones_from_prompt(prompt);
+        let active_zones = crate::memory::schema::parse_zones_from_prompt(prompt);
         let session_documents: Vec<_> = documents
             .iter()
             .filter(|document| document.session_id == session_id)
@@ -378,32 +378,6 @@ struct PlanConfig {
     max_tokens: usize,
     include_tool_calls: bool,
     include_metadata: bool,
-}
-
-fn parse_zones_from_prompt(prompt: &str) -> Vec<ContextZone> {
-    let lowered = prompt.to_lowercase();
-    let mut zones = Vec::new();
-
-    if lowered.contains("detalle") || lowered.contains("atómico") || lowered.contains("atomic") {
-        zones.push(ContextZone::Atomic);
-    }
-    if lowered.contains("resumen") || lowered.contains("cluster") || lowered.contains("agrupar") {
-        zones.push(ContextZone::Cluster);
-    }
-    if lowered.contains("general") || lowered.contains("global") || lowered.contains("estrategia") {
-        zones.push(ContextZone::Global);
-    }
-    if lowered.contains("relación") || lowered.contains("vínculo") || lowered.contains("grafo") || lowered.contains("belief") {
-        zones.push(ContextZone::Relational);
-    }
-
-    if zones.is_empty() {
-        // Default zones based on implicit intent if none specified
-        zones.push(ContextZone::Atomic);
-        zones.push(ContextZone::Cluster);
-    }
-
-    zones
 }
 
 fn build_query(prompt: &str, level: ContextLevel, hook: HookKind) -> String {

--- a/src/memory/schema.rs
+++ b/src/memory/schema.rs
@@ -125,6 +125,32 @@ pub enum ContextZone {
     Relational,  // Beliefs and knowledge graph relations
 }
 
+pub fn parse_zones_from_prompt(prompt: &str) -> Vec<ContextZone> {
+    let lowered = prompt.to_lowercase();
+    let mut zones = Vec::new();
+
+    if lowered.contains("detalle") || lowered.contains("atómico") || lowered.contains("atomic") {
+        zones.push(ContextZone::Atomic);
+    }
+    if lowered.contains("resumen") || lowered.contains("cluster") || lowered.contains("agrupar") {
+        zones.push(ContextZone::Cluster);
+    }
+    if lowered.contains("general") || lowered.contains("global") || lowered.contains("estrategia") {
+        zones.push(ContextZone::Global);
+    }
+    if lowered.contains("relación") || lowered.contains("vínculo") || lowered.contains("grafo") || lowered.contains("belief") {
+        zones.push(ContextZone::Relational);
+    }
+
+    if zones.is_empty() {
+        // Default zones based on implicit intent if none specified
+        zones.push(ContextZone::Atomic);
+        zones.push(ContextZone::Cluster);
+    }
+
+    zones
+}
+
 impl ContextZone {
     pub fn as_str(&self) -> &'static str {
         match self {

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -21,7 +21,7 @@ use crate::{
     domain::memory::belief::{BeliefNode, BeliefEdge},
     memory::entity_graph::EntityRecord,
     memory::qmd_memory::MemoryDocument,
-    memory::schema::{MemoryQueryFilters, TypedMemoryPayload},
+    memory::schema::{ContextZone, MemoryQueryFilters, TypedMemoryPayload},
     memory::sqlite_vec_store::VecSqliteMemoryStore,
     memory::store::{GraphHopResult, HybridSearchMode},
     retrieval::gating::{AdaptiveGating, LayerWeights, SessionSummary},
@@ -516,6 +516,9 @@ pub struct MultiLayerRetrieveRequest {
     /// Include coherence report
     #[serde(default)]
     pub include_coherence: bool,
+    /// Targeted zones for retrieval (optional, falls back to prompt keywords)
+    #[serde(default)]
+    pub active_zones: Option<Vec<ContextZone>>,
 }
 
 fn default_relevance_threshold() -> f32 {
@@ -1082,12 +1085,17 @@ async fn build_multi_layer_retrieve_response(
 ) -> MultiLayerRetrieveResponse {
     let weights = payload.layer_weights.unwrap_or_default();
 
+    let active_zones = payload
+        .active_zones
+        .clone()
+        .unwrap_or_else(|| crate::memory::schema::parse_zones_from_prompt(&payload.query));
+
     let gating = AdaptiveGating::new(crate::retrieval::gating::GatingConfig {
         layer_weights: weights,
         relevance_threshold: payload.relevance_threshold.clamp(0.0, 1.0),
         rrf_k: payload.rrf_k,
         max_results: payload.limit.max(1),
-        active_zones: None,
+        active_zones: Some(active_zones),
     });
 
     let working_docs = workspace.workspace.memory.all_documents().await;

--- a/src/server/v1_api.rs
+++ b/src/server/v1_api.rs
@@ -12,8 +12,8 @@ use crate::{
     memory::{
         qmd_memory::query_with_embedding_filtered,
         schema::{
-            EvidenceKind, MemoryKind, MemoryNamespace, MemoryProvenance, MemoryQueryFilters,
-            TypedMemoryPayload,
+            ContextZone, EvidenceKind, MemoryKind, MemoryNamespace, MemoryProvenance,
+            MemoryQueryFilters, TypedMemoryPayload,
         },
     },
     workspace::WorkspaceContext,
@@ -69,6 +69,7 @@ pub struct V1SearchRequest {
     pub query: String,
     pub limit: Option<usize>,
     pub filters: Option<MemoryQueryFilters>,
+    pub active_zones: Option<Vec<ContextZone>>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -202,11 +203,19 @@ pub async fn v1_memories_search(
     Json(payload): Json<V1SearchRequest>,
 ) -> impl IntoResponse {
     let limit = payload.limit.unwrap_or(10);
+
+    let mut filters = payload.filters.clone().unwrap_or_default();
+    let zones = payload
+        .active_zones
+        .clone()
+        .unwrap_or_else(|| crate::memory::schema::parse_zones_from_prompt(&payload.query));
+    filters.zones = Some(zones);
+
     let results = query_with_embedding_filtered(
         &workspace.workspace.memory,
         &payload.query,
         limit,
-        payload.filters.as_ref(),
+        Some(&filters),
     )
     .await
     .unwrap_or_default()


### PR DESCRIPTION
This PR exposes the `active_zones` field in the memory search and retrieve API endpoints. PROGRAMMATIC API consumers can now specify which zones (atomic, cluster, global, relational) to activate for a query, allowing for targeted retrieval boosting. If `active_zones` is not provided, the system falls back to detecting zones from prompt keywords using the `parse_zones_from_prompt` logic.

Changes:
- `src/memory/schema.rs`: Relocated `parse_zones_from_prompt` here and made it public.
- `src/context/orchestrator.rs`: Updated to use the relocated function.
- `src/server/http.rs`: Added `active_zones` to `MultiLayerRetrieveRequest` and wired it in the retrieval response builder.
- `src/server/v1_api.rs`: Added `active_zones` to `V1SearchRequest` and applied it to the search filters.
- `src/cli/server.rs`: Added `active_zones` to `SearchPayload` and integrated it into the search handler.

Fixes #362

---
*PR created automatically by Jules for task [6820581914053440401](https://jules.google.com/task/6820581914053440401) started by @iberi22*