### PR TITLE
Dynamic Indexing Lag Calculation for SessionSyncTask

### DIFF
--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -368,7 +368,7 @@ pub async fn start_http_server(port: u16) -> Result<()> {
     }
 
     // Start session sync task cron (M5)
-    let sync_task = SessionSyncTask::new(health_adapter);
+    let sync_task = SessionSyncTask::with_storage(health_adapter, Some(dyn_store));
     let sync_shutdown = sync_task.spawn_cron_once();
     if sync_shutdown.is_some() {
         info!("SessionSyncTask cron started");
@@ -395,9 +395,15 @@ pub async fn start_http_server(port: u16) -> Result<()> {
 /// Server startup time for uptime tracking
 static START_TIME: once_cell::sync::Lazy<Instant> = once_cell::sync::Lazy::new(Instant::now);
 
-pub async fn health_handler() -> Response {
+pub async fn health_handler(State(state): State<CliState>) -> Response {
     // Uptime in seconds since startup
     let uptime_secs = START_TIME.elapsed().as_secs();
+
+    let lag_ms = xavier::tasks::session_sync_task::calculate_indexing_lag(
+        state.store.as_ref(),
+        &state.workspace_id,
+    )
+    .await;
 
     // Determine embedding provider mode from env
     let embedding_provider = std::env::var("XAVIER_EMBEDDING_PROVIDER_MODE")
@@ -432,6 +438,7 @@ pub async fn health_handler() -> Response {
             "embedding_provider": embedding_provider,
             "sqlite_db_size": sqlite_db_size,
             "uptime": uptime_secs,
+            "lag_ms": lag_ms,
         }),
     )
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -2,7 +2,6 @@
 
 use axum::{
     extract::{ws::Message, ws::WebSocket, State, WebSocketUpgrade},
-    http::StatusCode,
     response::IntoResponse,
     Extension, Json,
 };
@@ -689,29 +688,24 @@ pub struct ResetMemoryResponse {
 /// Basic liveness probe — returns 200 if the process is alive.
 /// Does NOT check dependencies. Fast and cheap; suitable for
 /// Kubernetes liveness probes.
-pub async fn health() -> impl IntoResponse {
-    const HEALTH_JSON: &str = concat!(
-        "{\"status\":\"ok\",\"service\":\"xavier\",\"version\":\"",
-        env!("CARGO_PKG_VERSION"),
-        "\"}"
-    );
-    match axum::response::Response::builder()
-        .header("Content-Type", "application/json")
-        .body(axum::body::Body::from(HEALTH_JSON))
-    {
-        Ok(response) => response,
-        Err(error) => {
-            error!(%error, "failed to build health response");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({
-                    "status": "error",
-                    "message": "failed to build health response"
-                })),
-            )
-                .into_response()
-        }
-    }
+pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
+    let workspace = state.workspace_registry.default_context().await;
+    let lag_ms = if let Some(ref context) = workspace {
+        crate::tasks::session_sync_task::calculate_indexing_lag(
+            context.workspace.durable_store().as_ref(),
+            &context.workspace_id,
+        )
+        .await
+    } else {
+        0
+    };
+
+    Json(serde_json::json!({
+        "status": "ok",
+        "service": "xavier",
+        "version": env!("CARGO_PKG_VERSION"),
+        "lag_ms": lag_ms,
+    }))
 }
 
 /// Detailed liveness + readiness probe for orchestration systems.

--- a/src/tasks/session_sync_task.rs
+++ b/src/tasks/session_sync_task.rs
@@ -328,7 +328,12 @@ impl SessionSyncTask {
         let active_agents = health_status.active_agents as u64;
 
         // 2. Calculate index lag from storage (actual session record timestamps)
-        let lag_ms = self.estimate_index_lag().await;
+        let mut lag_ms = self.estimate_index_lag().await;
+
+        // Fallback to health status lag if local estimation is 0 (e.g. no local storage configured)
+        if lag_ms == 0 && health_status.lag_ms > 0 {
+            lag_ms = health_status.lag_ms;
+        }
 
         if health_status.status != "ok" && health_status.status != "degraded" {
             alerts.push(format!("Xavier health status: {}", health_status.status));
@@ -443,29 +448,7 @@ impl SessionSyncTask {
         if let Some(ref storage) = self.memory_store {
             let workspace_id = std::env::var("XAVIER_DEFAULT_WORKSPACE_ID")
                 .unwrap_or_else(|_| "default".to_string());
-            let filters = MemoryQueryFilters {
-                kinds: Some(vec![MemoryKind::Session]),
-                ..MemoryQueryFilters::default()
-            };
-
-            let records = match storage.list_filtered(&workspace_id, &filters, 100).await {
-                Ok(recs) => recs,
-                Err(e) => {
-                    tracing::warn!(error = %e, "Failed to list session records for lag estimation");
-                    return 0;
-                }
-            };
-
-            if let Some((event_ts, indexed_ts)) = records
-                .iter()
-                .filter_map(|record| {
-                    session_event_timestamp_ms(&record.content)
-                        .map(|ts| (ts, record.updated_at.timestamp_millis()))
-                })
-                .max_by_key(|(event_ts, _)| *event_ts)
-            {
-                return indexed_ts.saturating_sub(event_ts).max(0) as u64;
-            }
+            return calculate_indexing_lag(storage.as_ref(), &workspace_id).await;
         }
 
         0
@@ -566,6 +549,49 @@ pub fn get_last_sync_result() -> SyncCheckResult {
         .read()
         .map(|r| r.clone())
         .unwrap_or_default()
+}
+
+/// Calculate dynamic indexing lag by comparing original event timestamps
+/// with actual SQLite commit times (updated_at) for recent session records.
+/// Returns the average lag in milliseconds.
+pub async fn calculate_indexing_lag(storage: &dyn MemoryStore, workspace_id: &str) -> u64 {
+    let filters = MemoryQueryFilters {
+        kinds: Some(vec![MemoryKind::Session]),
+        ..MemoryQueryFilters::default()
+    };
+
+    // Fetch the last 10 session records for a representative sample
+    let records = match storage.list_filtered(workspace_id, &filters, 10).await {
+        Ok(recs) => recs,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to list session records for lag estimation");
+            return 0;
+        }
+    };
+
+    if records.is_empty() {
+        return 0;
+    }
+
+    let mut total_lag = 0;
+    let mut count = 0;
+
+    for record in records {
+        if let Some(event_ts) = session_event_timestamp_ms(&record.content) {
+            let indexed_ts = record.updated_at.timestamp_millis();
+            let lag = indexed_ts.saturating_sub(event_ts);
+            if lag >= 0 {
+                total_lag += lag;
+                count += 1;
+            }
+        }
+    }
+
+    if count > 0 {
+        (total_lag / count) as u64
+    } else {
+        0
+    }
 }
 
 fn read_env_or_legacy(primary: &str, legacy: &str) -> Option<String> {


### PR DESCRIPTION
The task was to replace the static/stub indexing lag calculation with a dynamic algorithm and improve the fallback strategy for `SessionSyncTask`.

I implemented the following:
1. **Dynamic Lag Calculation**: A new `calculate_indexing_lag` function in `src/tasks/session_sync_task.rs` that averages the difference between event timestamps and storage timestamps for the last 10 session records.
2. **Fallback Mechanism**: Improved `SessionSyncTask` to use the lag reported by the remote health check if local estimation is zero (useful when local storage isn't fully configured or when monitoring remote instances).
3. **API Exposure**: Both the CLI server and the app server's `/health` endpoints now report `lag_ms` dynamically.
4. **Integration**: Properly initialized `SessionSyncTask` with access to the local `MemoryStore` in the CLI server.

Verified the logic with unit tests and ensured no regressions in sync check handling.

Fixes #382

---
*PR created automatically by Jules for task [5642335614437142305](https://jules.google.com/task/5642335614437142305) started by @iberi22*