### PR TITLE
Remove insecure dev-token fallbacks in production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
     needs: [panel-check]
     env:
       XAVIER_TOKEN: dev-token
+      XAVIER_DEV_MODE: 1
       XAVIER_URL: http://127.0.0.1:8003
       XAVIER_HOST: 127.0.0.1
       XAVIER_PORT: 8003
@@ -140,6 +141,7 @@ jobs:
     needs: [panel-check, check, clippy, test, build, panel-e2e]
     env:
       XAVIER_TOKEN: dev-token
+      XAVIER_DEV_MODE: 1
       XAVIER_URL: http://127.0.0.1:8003
       XAVIER_HOST: 127.0.0.1
       XAVIER_PORT: 8003

--- a/backup/docker-compose.yml.bak-surreal-fix
+++ b/backup/docker-compose.yml.bak-surreal-fix
@@ -13,7 +13,7 @@ services:
       - XAVIER_PORT=8003
       - XAVIER_HOST=0.0.0.0
       - XAVIER_CODE_GRAPH_DB_PATH=/data/code_graph.db
-      - XAVIER_TOKEN=${XAVIER_TOKEN:-dev-token}
+      - XAVIER_TOKEN=${XAVIER_TOKEN}
       # FIXED: Using file backend for reliable local persistence
       # SurrealDB integration disabled due to persistent write failures (see BENCHMARKS.md)
       - XAVIER_MEMORY_BACKEND=file

--- a/panel-ui/tests/generative-ui.spec.ts
+++ b/panel-ui/tests/generative-ui.spec.ts
@@ -4,6 +4,7 @@ const appPath = process.env.PANEL_UI_APP_PATH ?? "/";
 const panelApiRoot = "/panel/api";
 const assetRoot =
   appPath === "/" ? "/assets" : `${appPath.replace(/\/$/, "")}/assets`;
+const testToken = process.env.XAVIER_TOKEN || "dev-token";
 const prompts = [
   "Explain xavier memory and show the answer as a structured UI.",
   "Summarize the current agent workflow as cards with supporting details.",
@@ -16,7 +17,7 @@ async function enterPanel(page: Page) {
     page.getByText("OpenUI cockpit for the internal agent"),
   ).toBeVisible();
 
-  await page.getByPlaceholder("XAVIER_TOKEN").fill("dev-token");
+  await page.getByPlaceholder("XAVIER_TOKEN").fill(testToken);
   await page.getByRole("button", { name: "Enter panel" }).click();
 
   await expect(page.getByRole("button", { name: "New thread" })).toBeVisible();
@@ -45,7 +46,7 @@ test.describe("Xavier generative panel", () => {
     const authorizedThreadsResponse = await request.get(
       `${panelApiRoot}/threads`,
       {
-        headers: { "X-Xavier-Token": "dev-token" },
+        headers: { "X-Xavier-Token": testToken },
       },
     );
     expect(authorizedThreadsResponse.status()).toBe(200);
@@ -95,7 +96,7 @@ test.describe("Xavier generative panel", () => {
     await expect(page.locator(".topbar h1")).not.toHaveText("New Thread");
 
     const threadsResponse = await request.get(`${panelApiRoot}/threads`, {
-      headers: { "X-Xavier-Token": "dev-token" },
+      headers: { "X-Xavier-Token": testToken },
     });
     const threads = (await threadsResponse.json()) as Array<{
       id: string;
@@ -108,7 +109,7 @@ test.describe("Xavier generative panel", () => {
     const detailResponse = await request.get(
       `${panelApiRoot}/threads/${activeThread?.id}`,
       {
-        headers: { "X-Xavier-Token": "dev-token" },
+        headers: { "X-Xavier-Token": testToken },
       },
     );
     expect(detailResponse.status()).toBe(200);

--- a/scripts/index-cli-histories.ps1
+++ b/scripts/index-cli-histories.ps1
@@ -9,7 +9,14 @@ param(
     [int]$MaxFilesPerTool = 50
 )
 
-if (-not $XavierToken) { $XavierToken = "dev-token" }
+if (-not $XavierToken) {
+    if ($env:XAVIER_DEV_MODE -eq "true" -or $env:XAVIER_DEV_MODE -eq "1") {
+        $XavierToken = "dev-token"
+    } else {
+        Write-Error "XAVIER_TOKEN environment variable is not set. For development, set XAVIER_DEV_MODE=true to use the default dev-token."
+        exit 1
+    }
+}
 
 $headers = @{
     "X-Xavier-Token" = $XavierToken

--- a/scripts/index-conversations.js
+++ b/scripts/index-conversations.js
@@ -4,8 +4,14 @@ const readline = require('readline');
 const http = require('http');
 
 const XAVIER_URL = 'http://localhost:8006';
-const XAVIER_TOKEN = process.env.XAVIER_TOKEN || 'dev-token';
+const XAVIER_TOKEN = process.env.XAVIER_TOKEN || (['true', '1'].includes(process.env.XAVIER_DEV_MODE) ? 'dev-token' : null);
 const MAX_CHUNK_SIZE = 12000;
+
+if (!XAVIER_TOKEN) {
+  console.error("Error: XAVIER_TOKEN environment variable is not set.");
+  console.error("For development, set XAVIER_DEV_MODE=true to use the default dev-token.");
+  process.exit(1);
+}
 const MAX_SESSIONS = 8;
 
 let totalIndexed = 0;

--- a/scripts/index-conversations.ps1
+++ b/scripts/index-conversations.ps1
@@ -3,10 +3,19 @@
 
 param(
     [string]$XavierUrl = "http://localhost:8006",
-    [string]$XavierToken = ($env:XAVIER_TOKEN, "dev-token" -ne $null)[0],
+    [string]$XavierToken = $env:XAVIER_TOKEN,
     [int]$MaxChunkSize = 15000,
     [int]$MaxSessionsPerTool = 10
 )
+
+if (-not $XavierToken) {
+    if ($env:XAVIER_DEV_MODE -eq "true" -or $env:XAVIER_DEV_MODE -eq "1") {
+        $XavierToken = "dev-token"
+    } else {
+        Write-Error "XAVIER_TOKEN environment variable is not set. For development, set XAVIER_DEV_MODE=true to use the default dev-token."
+        exit 1
+    }
+}
 
 $headers = @{
     "X-Xavier-Token" = $XavierToken

--- a/scripts/xavier-bpm-health.js
+++ b/scripts/xavier-bpm-health.js
@@ -5,8 +5,14 @@ const path = require('path');
 const os = require('os');
 
 const XAVIER_URL = process.env.XAVIER_URL || 'http://localhost:8006';
-const TOKEN = process.env.XAVIER_TOKEN || 'dev-token';
+const TOKEN = process.env.XAVIER_TOKEN || (['true', '1'].includes(process.env.XAVIER_DEV_MODE) ? 'dev-token' : null);
 const TIMEOUT = 5000;
+
+if (!TOKEN) {
+  console.error("Error: XAVIER_TOKEN environment variable is not set.");
+  console.error("For development, set XAVIER_DEV_MODE=true to use the default dev-token.");
+  process.exit(1);
+}
 
 function log(msg) {
   const timestamp = new Date().toISOString();

--- a/scripts/xavier-full-test.ps1
+++ b/scripts/xavier-full-test.ps1
@@ -3,8 +3,17 @@
 
 param(
     [string]$XavierUrl = "http://localhost:8006",
-    [string]$XavierToken = ($env:XAVIER_TOKEN, "dev-token" -ne $null)[0]
+    [string]$XavierToken = $env:XAVIER_TOKEN
 )
+
+if (-not $XavierToken) {
+    if ($env:XAVIER_DEV_MODE -eq "true" -or $env:XAVIER_DEV_MODE -eq "1") {
+        $XavierToken = "dev-token"
+    } else {
+        Write-Error "XAVIER_TOKEN environment variable is not set. For development, set XAVIER_DEV_MODE=true to use the default dev-token."
+        exit 1
+    }
+}
 
 $headers = @{
     "X-Xavier-Token" = $XavierToken

--- a/scripts/xavier-health-check.js
+++ b/scripts/xavier-health-check.js
@@ -4,8 +4,14 @@ const path = require('path');
 const os = require('os');
 
 const XAVIER_URL = process.env.XAVIER_URL || 'http://localhost:8006';
-const TOKEN = process.env.XAVIER_TOKEN || 'dev-token';
+const TOKEN = process.env.XAVIER_TOKEN || (['true', '1'].includes(process.env.XAVIER_DEV_MODE) ? 'dev-token' : null);
 const TIMEOUT = 5000;
+
+if (!TOKEN) {
+  console.error("Error: XAVIER_TOKEN environment variable is not set.");
+  console.error("For development, set XAVIER_DEV_MODE=true to use the default dev-token.");
+  process.exit(1);
+}
 
 function log(msg) {
   const timestamp = new Date().toISOString();

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -11,15 +11,13 @@
 //! `XAVIER_URL` is the canonical configuration variable. All CLI commands (`add`,
 //! `search`, `stats`, etc.) resolve the server URL through this module.
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::path::PathBuf;
 
 use crate::settings::XavierSettings;
 
 pub fn resolve_http_token() -> Result<String> {
-    XavierSettings::current().auth_token.ok_or_else(|| {
-        anyhow!("XAVIER_TOKEN environment variable must be set to start the HTTP server.")
-    })
+    xavier::security::auth::resolve_xavier_token()
 }
 
 
@@ -68,15 +66,11 @@ pub fn resolve_http_port() -> u16 {
 }
 
 pub fn xavier_token() -> String {
-    XavierSettings::current()
-        .auth_token
-        .expect("XAVIER_TOKEN environment variable must be set for CLI client commands")
+    xavier::security::auth::resolve_xavier_token().expect("XAVIER_TOKEN environment variable must be set for CLI client commands")
 }
 
 pub fn require_xavier_token() -> Result<String> {
-    XavierSettings::current()
-        .auth_token
-        .ok_or_else(|| anyhow!("XAVIER_TOKEN environment variable must be set for CLI client commands"))
+    xavier::security::auth::resolve_xavier_token()
 }
 
 pub fn code_graph_db_path() -> PathBuf {

--- a/src/security/auth.rs
+++ b/src/security/auth.rs
@@ -14,23 +14,25 @@ use tokio::sync::RwLock;
 /// If `XAVIER_TOKEN` is set, returns its value.
 ///
 /// If `XAVIER_TOKEN` is unset:
-/// - With the `dev-mode` feature enabled, falls back to `"dev-token"`.
-/// - Without `dev-mode` (the default), returns an error.
+/// - With the `dev-mode` feature enabled OR `XAVIER_DEV_MODE=true`, falls back to `"dev-token"`.
+/// - Without dev mode (the default), returns an error.
 pub fn resolve_xavier_token() -> Result<String> {
-    match std::env::var("XAVIER_TOKEN") {
-        Ok(token) => Ok(token),
-        Err(_) => {
-            #[cfg(feature = "dev-mode")]
-            {
-                Ok("dev-token".to_string())
-            }
-            #[cfg(not(feature = "dev-mode"))]
-            {
-                Err(anyhow!(
-                    "XAVIER_TOKEN environment variable is not set"
-                ))
-            }
-        }
+    if let Ok(token) = std::env::var("XAVIER_TOKEN") {
+        return Ok(token);
+    }
+
+    let dev_mode_env = std::env::var("XAVIER_DEV_MODE")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
+
+    let dev_mode_feat = cfg!(feature = "dev-mode");
+
+    if dev_mode_env || dev_mode_feat {
+        Ok("dev-token".to_string())
+    } else {
+        Err(anyhow!(
+            "XAVIER_TOKEN environment variable is not set. For development, set XAVIER_DEV_MODE=true to use the default dev-token."
+        ))
     }
 }
 
@@ -345,5 +347,47 @@ mod tests {
 
         let found = store.get_by_email("test@example.com").await;
         assert!(found.is_some());
+    }
+
+    #[test]
+    fn test_resolve_xavier_token() {
+        // Clean environment
+        std::env::remove_var("XAVIER_TOKEN");
+        std::env::remove_var("XAVIER_DEV_MODE");
+
+        // Case 1: No token, no dev mode
+        let result = resolve_xavier_token();
+        #[cfg(not(feature = "dev-mode"))]
+        assert!(result.is_err());
+        #[cfg(feature = "dev-mode")]
+        assert_eq!(result.unwrap(), "dev-token");
+
+        // Case 2: XAVIER_TOKEN set
+        std::env::set_var("XAVIER_TOKEN", "secure-token");
+        let result = resolve_xavier_token();
+        assert_eq!(result.unwrap(), "secure-token");
+
+        // Case 3: XAVIER_DEV_MODE=true
+        std::env::remove_var("XAVIER_TOKEN");
+        std::env::set_var("XAVIER_DEV_MODE", "true");
+        let result = resolve_xavier_token();
+        assert_eq!(result.unwrap(), "dev-token");
+
+        // Case 4: XAVIER_DEV_MODE=1
+        std::env::set_var("XAVIER_DEV_MODE", "1");
+        let result = resolve_xavier_token();
+        assert_eq!(result.unwrap(), "dev-token");
+
+        // Case 5: XAVIER_DEV_MODE=false
+        std::env::set_var("XAVIER_DEV_MODE", "false");
+        let result = resolve_xavier_token();
+        #[cfg(not(feature = "dev-mode"))]
+        assert!(result.is_err());
+        #[cfg(feature = "dev-mode")]
+        assert_eq!(result.unwrap(), "dev-token");
+
+        // Cleanup
+        std::env::remove_var("XAVIER_TOKEN");
+        std::env::remove_var("XAVIER_DEV_MODE");
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -141,7 +141,9 @@ mod integration {
     async fn test_verify_save_endpoint() {
         let server = spawn_test_server().await;
         std::env::set_var("XAVIER_URL", &server.base_url);
-        std::env::set_var("X-CORTEX-TOKEN", "dev-token");
+        if std::env::var("X-CORTEX-TOKEN").is_err() {
+            std::env::set_var("X-CORTEX-TOKEN", "dev-token");
+        }
 
         let response = post_json(
             &server,


### PR DESCRIPTION
This change removes insecure default authentication fallbacks to the hardcoded "dev-token" string across the codebase. It introduces a centralized `resolve_xavier_token` function in the security module that strictly requires `XAVIER_TOKEN` in production. Development environments can still use the default token by explicitly setting the `XAVIER_DEV_MODE` environment variable to `true` or `1`, or by enabling the `dev-mode` Cargo feature. All CLI commands, server endpoints, and auxiliary scripts have been updated to follow this security policy. CI/CD pipelines have also been updated to ensure tests continue to run by explicitly enabling dev mode.

Fixes #404

---
*PR created automatically by Jules for task [18142714451211000339](https://jules.google.com/task/18142714451211000339) started by @iberi22*