### PR TITLE
Build Official Native SDKs for Python and TypeScript/Node.js

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,0 +1,58 @@
+# Xavier Python SDK (xavier-py)
+
+Professional-grade Python SDK for interacting with Xavier's high-performance memory API.
+
+## Installation
+
+```bash
+pip install xavier-py
+```
+
+## Quickstart
+
+### Synchronous Usage
+
+```python
+from xavier_py import XavierClient
+
+# Auto-resolves XAVIER_TOKEN from environment
+client = XavierClient(base_url="http://localhost:8080")
+
+# Add a memory
+client.add("Xavier is a high-performance memory engine.", path="docs/intro")
+
+# Search
+results = client.search("What is Xavier?", limit=5)
+for doc in results.results:
+    print(f"[{doc.path}] {doc.content}")
+```
+
+### Asynchronous Usage
+
+```python
+import asyncio
+from xavier_py import XavierClient
+
+async def main():
+    client = XavierClient()
+
+    # Add memory asynchronously
+    await client.add_async("Episodic memory stores session history.", path="docs/episodic")
+
+    # Retrieve across layers
+    response = await client.retrieve_async("Tell me about episodic memory")
+    print(f"Found {len(response.results)} results across {response.layers_used.total_results} total items.")
+
+asyncio.run(main())
+```
+
+## Features
+
+- **Sync & Async**: Built-in support for both `requests` and `aiohttp`.
+- **Type Safety**: Fully validated responses using Pydantic models.
+- **Auto-Auth**: Automatically picks up `XAVIER_TOKEN` from the environment.
+- **Multi-layer Retrieval**: Easy access to Xavier's hybrid retrieval system.
+
+## License
+
+MIT

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "xavier-py"
+version = "0.1.0"
+description = "Official Python SDK for Xavier Memory API"
+authors = [
+    { name = "SouthWest AI Labs" }
+]
+dependencies = [
+    "requests>=2.31.0",
+    "aiohttp>=3.9.0",
+    "pydantic>=2.0.0"
+]
+requires-python = ">=3.8"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,0 +1,78 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock
+from xavier_py import XavierClient, SearchResponse, StatsResponse
+
+@pytest.fixture
+def client():
+    return XavierClient(base_url="http://localhost:8080", token="test-token")
+
+def test_client_init_token():
+    with patch.dict(os.environ, {"XAVIER_TOKEN": "env-token"}):
+        client = XavierClient()
+        assert client.token == "env-token"
+
+def test_get_headers(client):
+    headers = client._get_headers()
+    assert headers["X-Xavier-Token"] == "test-token"
+    assert headers["Content-Type"] == "application/json"
+
+@patch("requests.post")
+def test_add(mock_post, client):
+    mock_post.return_value.json.return_value = {"status": "ok", "id": "123"}
+    mock_post.return_value.status_code = 200
+
+    result = client.add("test content", path="test/path")
+
+    assert result["status"] == "ok"
+    assert result["id"] == "123"
+    mock_post.assert_called_once()
+
+@patch("requests.post")
+def test_search(mock_post, client):
+    mock_post.return_value.json.return_value = {
+        "status": "ok",
+        "query": "test query",
+        "results": [
+            {"id": "1", "path": "p1", "content": "c1", "metadata": {}}
+        ]
+    }
+    mock_post.return_value.status_code = 200
+
+    response = client.search("test query")
+
+    assert isinstance(response, SearchResponse)
+    assert response.status == "ok"
+    assert len(response.results) == 1
+    assert response.results[0].content == "c1"
+
+@patch("requests.get")
+def test_stats(mock_get, client):
+    mock_get.return_value.json.return_value = {
+        "status": "ok",
+        "workspace_id": "default",
+        "version": "0.6.1-beta"
+    }
+    mock_get.return_value.status_code = 200
+
+    response = client.stats()
+
+    assert isinstance(response, StatsResponse)
+    assert response.version == "0.6.1-beta"
+
+@pytest.mark.asyncio
+async def test_add_async(client):
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+
+        # Async mock for .json()
+        async def mock_json():
+            return {"status": "ok", "id": "async-123"}
+        mock_resp.json = mock_json
+
+        mock_resp.__aenter__.return_value = mock_resp
+        mock_post.return_value = mock_resp
+
+        result = await client.add_async("async content")
+        assert result["id"] == "async-123"

--- a/clients/python/xavier_py/__init__.py
+++ b/clients/python/xavier_py/__init__.py
@@ -1,0 +1,25 @@
+from .client import XavierClient
+from .models import (
+    MemoryNode,
+    RetrievedMemory,
+    LayerStats,
+    SearchResponse,
+    RetrieveResponse,
+    GraphNode,
+    GraphEdge,
+    GraphResponse,
+    StatsResponse
+)
+
+__all__ = [
+    "XavierClient",
+    "MemoryNode",
+    "RetrievedMemory",
+    "LayerStats",
+    "SearchResponse",
+    "RetrieveResponse",
+    "GraphNode",
+    "GraphEdge",
+    "GraphResponse",
+    "StatsResponse"
+]

--- a/clients/python/xavier_py/client.py
+++ b/clients/python/xavier_py/client.py
@@ -1,0 +1,183 @@
+import os
+import requests
+import aiohttp
+import asyncio
+from typing import Optional, List, Dict, Any, Union
+from .models import (
+    SearchResponse,
+    RetrieveResponse,
+    StatsResponse,
+    GraphResponse
+)
+
+class XavierClient:
+    """
+    Official Python SDK for Xavier Memory API.
+    Supports both synchronous (using requests) and asynchronous (using aiohttp) operations.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8080",
+        token: Optional[str] = None
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.token = token or os.environ.get("XAVIER_TOKEN")
+
+        if not self.token:
+            # Fallback to dev-token if not provided and not in production
+            self.token = "dev-token"
+
+    def _get_headers(self) -> Dict[str, str]:
+        return {
+            "X-Xavier-Token": self.token,
+            "Content-Type": "application/json"
+        }
+
+    # --- Synchronous Methods ---
+
+    def add(
+        self,
+        content: str,
+        path: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Add a document to memory."""
+        url = f"{self.base_url}/memory/add"
+        payload = {
+            "content": content,
+            "path": path,
+            "metadata": metadata,
+            **kwargs
+        }
+        response = requests.post(url, json=payload, headers=self._get_headers())
+        response.raise_for_status()
+        return response.json()
+
+    def search(
+        self,
+        query: str,
+        limit: int = 10,
+        filters: Optional[Dict[str, Any]] = None
+    ) -> SearchResponse:
+        """Search memory with semantic + lexical hybrid search."""
+        url = f"{self.base_url}/memory/search"
+        payload = {
+            "query": query,
+            "limit": limit,
+            "filters": filters
+        }
+        response = requests.post(url, json=payload, headers=self._get_headers())
+        response.raise_for_status()
+        return SearchResponse(**response.json())
+
+    def retrieve(
+        self,
+        query: str,
+        limit: int = 10,
+        **kwargs
+    ) -> RetrieveResponse:
+        """Perform multi-layer memory retrieval."""
+        url = f"{self.base_url}/memory/retrieve"
+        payload = {
+            "query": query,
+            "limit": limit,
+            **kwargs
+        }
+        response = requests.post(url, json=payload, headers=self._get_headers())
+        response.raise_for_status()
+        return RetrieveResponse(**response.json())
+
+    def stats(self) -> StatsResponse:
+        """Get memory statistics."""
+        url = f"{self.base_url}/memory/stats"
+        response = requests.get(url, headers=self._get_headers())
+        response.raise_for_status()
+        return StatsResponse(**response.json())
+
+    def delete(self, id: Optional[str] = None, path: Optional[str] = None) -> Dict[str, Any]:
+        """Delete a memory entry by id or path."""
+        url = f"{self.base_url}/memory/delete"
+        payload = {"id": id, "path": path}
+        response = requests.post(url, json=payload, headers=self._get_headers())
+        response.raise_for_status()
+        return response.json()
+
+    # --- Asynchronous Methods ---
+
+    async def add_async(
+        self,
+        content: str,
+        path: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs
+    ) -> Dict[str, Any]:
+        """Add a document to memory (Async)."""
+        url = f"{self.base_url}/memory/add"
+        payload = {
+            "content": content,
+            "path": path,
+            "metadata": metadata,
+            **kwargs
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, headers=self._get_headers()) as response:
+                response.raise_for_status()
+                return await response.json()
+
+    async def search_async(
+        self,
+        query: str,
+        limit: int = 10,
+        filters: Optional[Dict[str, Any]] = None
+    ) -> SearchResponse:
+        """Search memory (Async)."""
+        url = f"{self.base_url}/memory/search"
+        payload = {
+            "query": query,
+            "limit": limit,
+            "filters": filters
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, headers=self._get_headers()) as response:
+                response.raise_for_status()
+                data = await response.json()
+                return SearchResponse(**data)
+
+    async def retrieve_async(
+        self,
+        query: str,
+        limit: int = 10,
+        **kwargs
+    ) -> RetrieveResponse:
+        """Multi-layer retrieval (Async)."""
+        url = f"{self.base_url}/memory/retrieve"
+        payload = {
+            "query": query,
+            "limit": limit,
+            **kwargs
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, headers=self._get_headers()) as response:
+                response.raise_for_status()
+                data = await response.json()
+                return RetrieveResponse(**data)
+
+    async def stats_async(self) -> StatsResponse:
+        """Get stats (Async)."""
+        url = f"{self.base_url}/memory/stats"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=self._get_headers()) as response:
+                response.raise_for_status()
+                data = await response.json()
+                return StatsResponse(**data)
+
+    async def delete_async(self, id: Optional[str] = None, path: Optional[str] = None) -> Dict[str, Any]:
+        """Delete entry (Async)."""
+        url = f"{self.base_url}/memory/delete"
+        payload = {"id": id, "path": path}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, headers=self._get_headers()) as response:
+                response.raise_for_status()
+                return await response.json()

--- a/clients/python/xavier_py/models.py
+++ b/clients/python/xavier_py/models.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from typing import List, Optional, Dict, Any
+from pydantic import BaseModel, Field
+
+class MemoryNode(BaseModel):
+    id: str
+    path: str
+    content: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+class RetrievedMemory(BaseModel):
+    id: str
+    content: str
+    score: float
+    source_layer: str
+    path: str
+
+class LayerStats(BaseModel):
+    working_count: int
+    episodic_count: int
+    semantic_count: int
+    total_results: int
+
+class SearchResponse(BaseModel):
+    status: str
+    results: List[MemoryNode]
+    query: str
+
+class RetrieveResponse(BaseModel):
+    status: str
+    results: List[RetrievedMemory]
+    query: str
+    layers_used: LayerStats
+
+class GraphNode(BaseModel):
+    id: str
+    concept: str
+    confidence: float
+    created_at: datetime
+
+class GraphEdge(BaseModel):
+    id: str
+    source: str
+    target: str
+    relation_type: str
+    weight: float
+    confidence_score: float
+    provenance_id: str
+    contradicts_edge_id: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+class GraphResponse(BaseModel):
+    status: str
+    nodes: List[GraphNode]
+    edges: List[GraphEdge]
+
+class StatsResponse(BaseModel):
+    status: str
+    workspace_id: str
+    version: str

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -1,0 +1,45 @@
+# Xavier TypeScript SDK (@iberi22/xavier)
+
+Official, async-first TypeScript SDK for the Xavier Memory API.
+
+## Installation
+
+```bash
+npm install @iberi22/xavier
+```
+
+## Quickstart
+
+```typescript
+import { XavierClient } from '@iberi22/xavier';
+
+// Auto-resolves XAVIER_TOKEN from process.env
+const client = new XavierClient({ baseUrl: 'http://localhost:8080' });
+
+async function main() {
+  // Add a memory
+  await client.add({
+    content: 'Xavier implements multi-layer RRF fusion for high-precision retrieval.',
+    path: 'tech/retrieval'
+  });
+
+  // Search
+  const results = await client.search('How does Xavier retrieve?', 5);
+  results.results.forEach(doc => {
+    console.log(`[${doc.path}] ${doc.content}`);
+  });
+}
+
+main().catch(console.error);
+```
+
+## Features
+
+- **Async-First**: Built for modern Node.js and browser environments.
+- **Full TypeScript Types**: Complete interfaces for all requests and responses.
+- **Auto-Auth**: Automatically uses `XAVIER_TOKEN` from the environment if available.
+- **Layered Retrieval**: Full support for Xavier's multi-layer memory architecture.
+
+## License
+
+MIT

--- a/clients/typescript/jest.config.js
+++ b/clients/typescript/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+};

--- a/clients/typescript/package.json
+++ b/clients/typescript/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@iberi22/xavier",
+  "version": "0.1.0",
+  "description": "Official TypeScript SDK for Xavier Memory API",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "author": "SouthWest AI Labs",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "@types/node": "^18.0.0"
+  }
+}

--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -1,0 +1,109 @@
+import {
+  AddMemoryRequest,
+  ClientOptions,
+  DeleteResponse,
+  RetrieveResponse,
+  SearchResponse,
+  StatsResponse,
+} from './types';
+
+export class XavierClient {
+  private baseUrl: string;
+  private token: string;
+
+  constructor(options: ClientOptions = {}) {
+    this.baseUrl = (options.baseUrl || 'http://localhost:8080').replace(/\/$/, '');
+    this.token = options.token || process.env.XAVIER_TOKEN || 'dev-token';
+  }
+
+  private getHeaders(): Record<string, string> {
+    return {
+      'X-Xavier-Token': this.token,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  /**
+   * Add a document to memory.
+   */
+  async add(payload: AddMemoryRequest): Promise<any> {
+    const response = await fetch(`${this.baseUrl}/memory/add`, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Xavier error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Search memory with semantic + lexical hybrid search.
+   */
+  async search(query: string, limit = 10, filters?: any): Promise<SearchResponse> {
+    const response = await fetch(`${this.baseUrl}/memory/search`, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify({ query, limit, filters }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Xavier error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<SearchResponse>;
+  }
+
+  /**
+   * Perform multi-layer memory retrieval.
+   */
+  async retrieve(query: string, limit = 10, options: any = {}): Promise<RetrieveResponse> {
+    const response = await fetch(`${this.baseUrl}/memory/retrieve`, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify({ query, limit, ...options }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Xavier error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<RetrieveResponse>;
+  }
+
+  /**
+   * Get memory statistics.
+   */
+  async stats(): Promise<StatsResponse> {
+    const response = await fetch(`${this.baseUrl}/memory/stats`, {
+      method: 'GET',
+      headers: this.getHeaders(),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Xavier error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<StatsResponse>;
+  }
+
+  /**
+   * Delete a memory entry by ID or path.
+   */
+  async delete(options: { id?: string; path?: string }): Promise<DeleteResponse> {
+    const response = await fetch(`${this.baseUrl}/memory/delete`, {
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify(options),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Xavier error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<DeleteResponse>;
+  }
+}

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -1,0 +1,2 @@
+export * from './client';
+export * from './types';

--- a/clients/typescript/src/types.ts
+++ b/clients/typescript/src/types.ts
@@ -1,0 +1,61 @@
+export interface MemoryNode {
+  id: string;
+  path: string;
+  content: string;
+  metadata: Record<string, any>;
+}
+
+export interface SearchResponse {
+  status: string;
+  results: MemoryNode[];
+  query: string;
+  count: number;
+  workspace_id?: string;
+}
+
+export interface RetrievedMemory {
+  id: string;
+  content: string;
+  score: number;
+  source_layer: string;
+  path: string;
+}
+
+export interface LayerStats {
+  working_count: number;
+  episodic_count: number;
+  semantic_count: number;
+  total_results: number;
+}
+
+export interface RetrieveResponse {
+  status: string;
+  results: RetrievedMemory[];
+  query: string;
+  layers_used: LayerStats;
+}
+
+export interface StatsResponse {
+  status: string;
+  workspace_id: string;
+  version: string;
+}
+
+export interface AddMemoryRequest {
+  content: string;
+  path?: string;
+  metadata?: Record<string, any>;
+  [key: string]: any;
+}
+
+export interface DeleteResponse {
+  status: string;
+  deleted: boolean;
+  id?: string;
+  path?: string;
+}
+
+export interface ClientOptions {
+  baseUrl?: string;
+  token?: string;
+}

--- a/clients/typescript/tests/client.test.ts
+++ b/clients/typescript/tests/client.test.ts
@@ -1,0 +1,67 @@
+import { XavierClient } from '../src/client';
+
+describe('XavierClient', () => {
+  let client: XavierClient;
+
+  beforeEach(() => {
+    client = new XavierClient({ baseUrl: 'http://localhost:8080', token: 'test-token' });
+    // Mock global fetch
+    (global as any).fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should use token from environment if not provided', () => {
+    process.env.XAVIER_TOKEN = 'env-token';
+    const c = new XavierClient();
+    expect((c as any).token).toBe('env-token');
+    delete process.env.XAVIER_TOKEN;
+  });
+
+  it('should add memory correctly', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'ok', id: '123' }),
+    });
+
+    const result = await client.add({ content: 'test' });
+    expect(result.id).toBe('123');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/memory/add'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'X-Xavier-Token': 'test-token',
+        }),
+      })
+    );
+  });
+
+  it('should search memory correctly', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        status: 'ok',
+        query: 'test query',
+        results: [{ id: '1', content: 'c1', path: 'p1', metadata: {} }],
+        count: 1
+      }),
+    });
+
+    const result = await client.search('test query');
+    expect(result.results.length).toBe(1);
+    expect(result.results[0].content).toBe('c1');
+  });
+
+  it('should handle errors', async () => {
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    });
+
+    await expect(client.stats()).rejects.toThrow('Xavier error: 401 Unauthorized');
+  });
+});

--- a/clients/typescript/tsconfig.json
+++ b/clients/typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "tests"]
+}


### PR DESCRIPTION
This PR introduces official, professional-grade native SDKs for the Xavier Memory API in Python and TypeScript/Node.js.

Key improvements:
- **Python SDK (xavier-py):** Located in `clients/python/`, it provides both sync and async clients, type safety via Pydantic, and automatic token resolution.
- **TypeScript SDK (@iberi22/xavier):** Located in `clients/typescript/`, it provides an async-first client with complete type definitions.
- **Documentation:** Clear `README.md` files in both directories with installation and usage examples.
- **Testing:** Unit tests for both SDKs using standard testing frameworks (pytest and jest) with mocking to ensure reliability.

These SDKs significantly improve the Developer Experience (DX) by abstracting manual HTTP requests and header management.

Fixes #416

---
*PR created automatically by Jules for task [18111244056600214250](https://jules.google.com/task/18111244056600214250) started by @iberi22*