### PR TITLE
fix: cleanup 22 clippy warnings across xavier codebase

### DIFF
--- a/src/memory/agent_indexer.rs
+++ b/src/memory/agent_indexer.rs
@@ -54,7 +54,7 @@ impl AgentIndexer {
 
     fn format_session_to_markdown(&self, session: &AgentSession) -> String {
         let mut md = String::new();
-        md.push_str(&format!("# Agent Conversation Session\n"));
+        md.push_str("# Agent Conversation Session\n");
         md.push_str(&format!("- **IDE/Tool**: {}\n", session.ide));
         if let Some(ref proj) = session.project_path {
             md.push_str(&format!("- **Project**: {}\n", proj));

--- a/src/memory/agent_scanner.rs
+++ b/src/memory/agent_scanner.rs
@@ -27,6 +27,12 @@ pub struct AgentScanner {
     search_paths: Vec<PathBuf>,
 }
 
+impl Default for AgentScanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AgentScanner {
     pub fn new() -> Self {
         let mut paths = Vec::new();
@@ -172,11 +178,10 @@ impl AgentScanner {
         // Naive heuristic for JSON that looks like chat history
         if content.contains("\"role\"") && content.contains("\"content\"") && content.contains("\"user\"") {
             // Attempt generic parsing
-            let mut messages = Vec::new();
-            messages.push(AgentMessage {
+            let messages = vec![AgentMessage {
                 role: "raw_json_extract".to_string(),
                 content: content.chars().take(3000).collect::<String>(), // Limit size
-            });
+            }];
 
             Ok(Some(AgentSession {
                 ide: "JSON_Agent".to_string(),

--- a/src/onboarding/scanner.rs
+++ b/src/onboarding/scanner.rs
@@ -231,6 +231,7 @@ pub fn scan_system() -> Result<SystemCapabilities, String> {
 #[cfg(target_os = "windows")]
 fn detect_ram_gb() -> f64 {
     #[repr(C)]
+    #[allow(non_snake_case)]
     struct MEMORYSTATUSEX {
         dwLength: u32,
         dwMemoryLoad: u32,

--- a/src/onboarding/scanner.rs
+++ b/src/onboarding/scanner.rs
@@ -231,7 +231,7 @@ pub fn scan_system() -> Result<SystemCapabilities, String> {
 #[cfg(target_os = "windows")]
 fn detect_ram_gb() -> f64 {
     #[repr(C)]
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, clippy::upper_case_acronyms)]
     struct MEMORYSTATUSEX {
         dwLength: u32,
         dwMemoryLoad: u32,

--- a/tests/clavis_integration.rs
+++ b/tests/clavis_integration.rs
@@ -70,7 +70,7 @@ async fn test_clavis_persistence_and_revocation() -> Result<()> {
 
     // 7. VERIFY Persistence in SQLite
     let conn = pool.get().await?;
-    let mut stmt = conn
+    let stmt = conn
         .prepare("SELECT event_type, agent_id, reason FROM secret_audit_logs ORDER BY id ASC")
         .await?;
     let mut rows = stmt.query(()).await?;

--- a/tests/sevier_stress_test.rs
+++ b/tests/sevier_stress_test.rs
@@ -125,7 +125,7 @@ async fn test_time_metric_save_and_retrieve() {
 
     // Verify row exists in SQLite
     let conn = db.get().await.expect("get connection from pool");
-    let mut stmt = conn
+    let stmt = conn
         .prepare("SELECT COUNT(*) FROM time_metrics WHERE agent_id = ?1")
         .await
         .expect("prepare should succeed");

--- a/tests/sync_check_handler_cached_result.rs
+++ b/tests/sync_check_handler_cached_result.rs
@@ -197,6 +197,6 @@ async fn sync_check_handler_returns_cached_result_from_session_sync_task() {
     assert_eq!(response.save_ok_rate, 1.0); // Default if check fails or not updated
     assert_eq!(response.match_score, 1.0);
     assert_eq!(response.timestamp_ms, sync_result.timestamp_ms);
-    assert!(response.alerts.len() >= 1);
+    assert!(!response.alerts.is_empty());
     assert!(response.alerts.iter().any(|a| a.contains("unreachable")));
 }


### PR DESCRIPTION
This PR cleans up 22 Clippy warnings to maintain high code quality and keep CI green. The fixes include:
1. Windows API struct naming (10 warnings): Added `#[allow(non_snake_case)]` to the `MEMORYSTATUSEX` struct in `src/onboarding/scanner.rs`.
2. Unused mutability: Fixed `unused_mut` warnings in `tests/sevier_stress_test.rs` and `tests/clavis_integration.rs`.
3. Vector initialization: Refactored `Vec::new()` followed by `push()` to use the `vec![]` macro in `src/memory/agent_scanner.rs`.
4. Clearer length checks: Replaced `.len() >= 1` with `!is_empty()` in `tests/sync_check_handler_cached_result.rs`.
5. Missing trait implementations: Added `Default` implementation for `AgentScanner`.
6. Other cleanups: Removed a `useless_format` macro in `src/memory/agent_indexer.rs`.

Verified by running `cargo clippy --all-targets` and confirming zero warnings remain. Relevant integration tests also pass.

Fixes #422

---
*PR created automatically by Jules for task [14960684223904609176](https://jules.google.com/task/14960684223904609176) started by @iberi22*