### PR TITLE
Strict project_id validation for path traversal security

### DIFF
--- a/src/codebase/conversations_db.rs
+++ b/src/codebase/conversations_db.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::OnceCell;
 use uuid::Uuid;
 use crate::codebase::connection_manager::ConnectionManager;
+use crate::codebase::validate_project_id;
 
 const CONVERSATIONS_DIR: &str = "conversations";
 
@@ -140,6 +141,7 @@ impl ConversationsDb {
     /// The database is stored at `~/.xavier/conversations/{project_id}.db`.
     /// The directory is created if it doesn't exist.
     pub async fn open(project_id: &str) -> Result<Self> {
+        validate_project_id(project_id)?;
         let full_project_id = format!("conv_{}", project_id);
         ConnectionManager::global().connect(&full_project_id, ".")?;
 
@@ -152,6 +154,7 @@ impl ConversationsDb {
 
     /// Open an in-memory conversations database (for testing).
     pub async fn open_in_memory(project_id: &str) -> Result<Self> {
+        validate_project_id(project_id)?;
         let full_project_id = format!("conv_test_{}", project_id);
         ConnectionManager::global().connect(&full_project_id, ".")?;
 
@@ -734,13 +737,9 @@ impl ConversationsDb {
     // Path helpers (port of original code)
     // ------------------------------------------------------------------
 
-    /// Build the database path for a given project_id, with path traversal sanitisation.
+    /// Build the database path for a given project_id, with path traversal validation.
     pub fn conversations_db_path(project_id: &str) -> PathBuf {
-        let sanitized: String = project_id
-            .chars()
-            .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
-            .collect();
-        assert!(!sanitized.is_empty(), "Invalid project_id: must contain at least one alphanumeric character, hyphen, or underscore");
+        validate_project_id(project_id).expect("Invalid project_id");
 
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
         let mut path = home;
@@ -748,11 +747,11 @@ impl ConversationsDb {
         path.push(CONVERSATIONS_DIR);
 
         let mut db_file = path.clone();
-        db_file.push(format!("{}.db", sanitized));
+        db_file.push(format!("{}.db", project_id));
 
         // Verify that the resolved path is within the expected directory
         if let Ok(canonical_base) = std::fs::canonicalize(&path) {
-            let resolved = canonical_base.join(format!("{}.db", sanitized));
+            let resolved = canonical_base.join(format!("{}.db", project_id));
             assert!(resolved.starts_with(&canonical_base), "Path escape detected");
         }
 
@@ -838,4 +837,42 @@ impl ConversationsDb {
 /// Parse an RFC 3339 datetime string.
 fn parse_datetime(s: &str) -> DateTime<Utc> {
     s.parse::<DateTime<Utc>>().unwrap_or_else(|_| Utc::now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_open_with_malicious_project_id() {
+        let mal_ids = vec!["../etc/passwd", "my/project", "project\\name", "~", " ", ""];
+        for id in mal_ids {
+            let res = ConversationsDb::open(id).await;
+            assert!(res.is_err(), "project_id '{}' should have been rejected", id);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_open_in_memory_with_malicious_project_id() {
+        let mal_ids = vec!["../etc/passwd", "my/project", "project\\name", "~", " ", ""];
+        for id in mal_ids {
+            let res = ConversationsDb::open_in_memory(id).await;
+            assert!(res.is_err(), "project_id '{}' should have been rejected", id);
+        }
+    }
+
+    #[test]
+    fn test_conversations_db_path_with_malicious_project_id() {
+        let mal_ids = vec!["../etc/passwd", "my/project", "project\\name", "~", " ", ""];
+        for id in mal_ids {
+            let res = std::panic::catch_unwind(|| ConversationsDb::conversations_db_path(id));
+            assert!(res.is_err(), "conversations_db_path should have panicked for project_id '{}'", id);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_open_valid_project_id() {
+        let db = ConversationsDb::open_in_memory("valid-project_123").await.unwrap();
+        assert_eq!(db.project_id(), "valid-project_123");
+    }
 }

--- a/src/codebase/db.rs
+++ b/src/codebase/db.rs
@@ -9,6 +9,7 @@ use rusqlite::params;
 use serde::{Deserialize, Serialize};
 use tokio::sync::OnceCell;
 use crate::codebase::connection_manager::ConnectionManager;
+use crate::codebase::validate_project_id;
 
 // ---------------------------------------------------------------------------
 // Result types
@@ -89,6 +90,7 @@ impl CodebaseDb {
     /// Open (or create) the codebase database at `project_root`.
     pub async fn open(project_root: &Path) -> Result<Self> {
         let project_id = "default"; // Or derive from path
+        validate_project_id(project_id)?;
         ConnectionManager::global().connect(project_id, &project_root.to_string_lossy())?;
         Ok(Self {
             project_id: project_id.to_string(),
@@ -99,6 +101,7 @@ impl CodebaseDb {
     /// Open an in-memory database (for testing).
     pub async fn open_in_memory() -> Result<Self> {
         let project_id = "test_in_memory";
+        validate_project_id(project_id)?;
         ConnectionManager::global().connect(project_id, ".")?;
         Ok(Self {
             project_id: project_id.to_string(),
@@ -573,6 +576,15 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    async fn test_open_with_malicious_project_id() {
+        let mal_ids = vec!["../etc/passwd", "my/project", "project\\name", "~", " ", ""];
+        for id in mal_ids {
+            // codebase::validate_project_id is already tested in mod.rs
+            assert!(validate_project_id(id).is_err());
+        }
+    }
+
+    #[tokio::test]
     async fn test_open_in_memory() {
         let db = CodebaseDb::open_in_memory().await.unwrap();
         db.create_schema().await.unwrap();
@@ -666,6 +678,12 @@ mod tests {
             0.9, Some("src/errors.rs"), 1, Some("if let Ok(v) = result"), "verified").await.unwrap();
         let c = count_rows(&db, "code_patterns").await;
         assert_eq!(c, 1);
+    }
+
+    #[tokio::test]
+    async fn test_open_valid_project_id() {
+        let db = CodebaseDb::open_in_memory().await.unwrap();
+        assert_eq!(db.project_id, "test_in_memory");
     }
 
     #[tokio::test]

--- a/src/codebase/mod.rs
+++ b/src/codebase/mod.rs
@@ -3,6 +3,52 @@
 //! Each repository gets its own `.xavier/codebase.db` (git + code data)
 //! plus a separate private conversations DB at `~/.xavier/conversations/{project_id}.db`.
 
+use anyhow::{anyhow, Result};
+use regex::Regex;
+use std::sync::LazyLock;
+
 pub mod connection_manager;
 pub mod conversations_db;
 pub mod db;
+
+/// Validation regex for project_id: only alphanumeric, hyphens, and underscores.
+static PROJECT_ID_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[a-zA-Z0-9_-]+$").expect("invalid project_id regex")
+});
+
+/// Validates that a project_id is safe to use in file paths.
+///
+/// It must be non-empty and contain only alphanumeric characters, hyphens, or underscores.
+/// This prevents path traversal attacks by rejecting '/', '..', '\', '~', etc.
+pub fn validate_project_id(project_id: &str) -> Result<()> {
+    if project_id.is_empty() {
+        return Err(anyhow!("project_id cannot be empty"));
+    }
+    if !PROJECT_ID_RE.is_match(project_id) {
+        return Err(anyhow!(
+            "Invalid project_id: '{}'. Only alphanumeric characters, hyphens, and underscores are allowed.",
+            project_id
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_project_id() {
+        assert!(validate_project_id("my-project").is_ok());
+        assert!(validate_project_id("project_123").is_ok());
+        assert!(validate_project_id("valid_ID-45").is_ok());
+
+        assert!(validate_project_id("").is_err());
+        assert!(validate_project_id("../etc/passwd").is_err());
+        assert!(validate_project_id("my/project").is_err());
+        assert!(validate_project_id("project\\name").is_err());
+        assert!(validate_project_id("~").is_err());
+        assert!(validate_project_id("project name").is_err());
+        assert!(validate_project_id("project@123").is_err());
+    }
+}


### PR DESCRIPTION
This change implements strict validation for `project_id` across the codebase module to mitigate path traversal risks. 

Key changes:
1. **New Validation Utility**: Introduced `validate_project_id` in `src/codebase/mod.rs` using a strict regex (`^[a-zA-Z0-9_-]+$`). This ensures that only safe characters are used for file-system-bound identifiers.
2. **Strict Enforcement**: All `open` and `open_in_memory` methods in `ConversationsDb` and `CodebaseDb` now validate the `project_id` before attempting to connect to the database.
3. **Refined Path Generation**: In `ConversationsDb::conversations_db_path`, we now use strict validation instead of loose sanitization, ensuring that any invalid `project_id` is caught immediately.
4. **Security Testing**: Added new test cases in `src/codebase/conversations_db.rs`, `src/codebase/db.rs`, and `src/codebase/mod.rs` to verify that dangerous strings like `../etc/passwd`, `~`, and paths containing separators are correctly rejected.

This approach follows the "fail fast" principle and provides a robust defense against path traversal via `project_id` manipulation.

Fixes #498

---
*PR created automatically by Jules for task [1392799450400382548](https://jules.google.com/task/1392799450400382548) started by @iberi22*