### PR TITLE
Replace ~30 unwrap() calls with error handling

### DIFF
--- a/src/agents/rate_limit.rs
+++ b/src/agents/rate_limit.rs
@@ -300,8 +300,14 @@ impl RateLimitManager {
 
 impl SchemaInitializer for RateLimitManager {
     fn init_schema(&self) -> Result<()> {
-        let rt = tokio::runtime::Handle::try_current()
-            .unwrap_or_else(|_| tokio::runtime::Runtime::new().unwrap().handle().clone());
+        let rt = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => handle,
+            Err(_) => {
+                let runtime = tokio::runtime::Runtime::new()
+                    .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {}", e))?;
+                runtime.handle().clone()
+            }
+        };
         rt.block_on(self.init_schema_async())
     }
 }

--- a/src/codebase/connection_manager.rs
+++ b/src/codebase/connection_manager.rs
@@ -60,7 +60,8 @@ impl ConnectionManager {
             } else if project_id == "metrics" {
                 PathBuf::from(project_root).join("metrics.db")
             } else if project_id.starts_with("conv_") {
-                let pid = project_id.strip_prefix("conv_").unwrap();
+                let pid = project_id.strip_prefix("conv_")
+                    .ok_or_else(|| anyhow::anyhow!("invalid conversation prefix"))?;
                 dirs::home_dir()
                     .ok_or_else(|| anyhow::anyhow!("could not find home directory"))?
                     .join(".xavier")

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("Internal error: {0}")]
+    Internal(String),
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,7 +1,10 @@
 pub mod agent;
 pub mod audit;
 pub mod belief;
+pub mod error;
 pub mod memory;
 pub mod pattern;
 pub mod proxy;
 pub mod security;
+
+pub use error::AppError;

--- a/src/enterprise/rate_limit.rs
+++ b/src/enterprise/rate_limit.rs
@@ -122,7 +122,7 @@ impl RateLimiter {
         let config = self.config.get(&key).cloned().unwrap_or_default();
 
         // Create quota based on config
-        let rpm = NonZeroU32::new(config.rpm).unwrap_or(NonZeroU32::new(1).unwrap());
+        let rpm = NonZeroU32::new(config.rpm).unwrap_or(unsafe { NonZeroU32::new_unchecked(1) });
         let burst = NonZeroU32::new(config.burst).unwrap_or(rpm);
 
         // Validate: burst should not exceed rpm (per minute quota)

--- a/src/memory/pack.rs
+++ b/src/memory/pack.rs
@@ -4,85 +4,91 @@ use std::fmt::Write;
 /// Generates a Context Pack (.xcp) in XML format from layered search results.
 pub fn generate_xcp(result: LayeredSearchResult, max_level: usize) -> String {
     let mut xml = String::new();
+    if let Err(e) = generate_xcp_to_writer(&mut xml, result, max_level) {
+        tracing::error!("Failed to generate XCP: {}", e);
+    }
+    xml
+}
+
+fn generate_xcp_to_writer(
+    xml: &mut String,
+    result: LayeredSearchResult,
+    max_level: usize,
+) -> std::fmt::Result {
     let topic_escaped = escape_xml(&result.topic);
 
     writeln!(
         xml,
         "<xavier_context_pack topic=\"{}\" generated=\"{}\">",
         topic_escaped, result.timestamp
-    )
-    .unwrap();
+    )?;
 
     // Level 0: Working Memory
     {
-        writeln!(xml, "  <level_0_working_memory>").unwrap();
+        writeln!(xml, "  <level_0_working_memory>")?;
         for r in result.level_0_working {
             writeln!(
                 xml,
                 "    <item score=\"{:.3}\" path=\"{}\">",
                 r.score,
                 escape_xml(&r.path)
-            )
-            .unwrap();
-            writeln!(xml, "      {}", escape_xml(&r.content)).unwrap();
-            writeln!(xml, "    </item>").unwrap();
+            )?;
+            writeln!(xml, "      {}", escape_xml(&r.content))?;
+            writeln!(xml, "    </item>")?;
         }
-        writeln!(xml, "  </level_0_working_memory>").unwrap();
+        writeln!(xml, "  </level_0_working_memory>")?;
     }
 
     // Level 1: Entity Graph
     if max_level >= 1 {
-        writeln!(xml, "  <level_1_entity_graph>").unwrap();
+        writeln!(xml, "  <level_1_entity_graph>")?;
         for r in result.level_1_entity_graph {
             writeln!(
                 xml,
                 "    <node score=\"{:.3}\" path=\"{}\">",
                 r.score,
                 escape_xml(&r.path)
-            )
-            .unwrap();
-            writeln!(xml, "      {}", escape_xml(&r.content)).unwrap();
-            writeln!(xml, "    </node>").unwrap();
+            )?;
+            writeln!(xml, "      {}", escape_xml(&r.content))?;
+            writeln!(xml, "    </node>")?;
         }
-        writeln!(xml, "  </level_1_entity_graph>").unwrap();
+        writeln!(xml, "  </level_1_entity_graph>")?;
     }
 
     // Level 2: Semantic (Rules/Definitions)
     if max_level >= 2 {
-        writeln!(xml, "  <level_2_semantic>").unwrap();
+        writeln!(xml, "  <level_2_semantic>")?;
         for r in result.level_2_semantic {
             writeln!(
                 xml,
                 "    <definition score=\"{:.3}\" path=\"{}\">",
                 r.score,
                 escape_xml(&r.path)
-            )
-            .unwrap();
-            writeln!(xml, "      {}", escape_xml(&r.content)).unwrap();
-            writeln!(xml, "    </definition>").unwrap();
+            )?;
+            writeln!(xml, "      {}", escape_xml(&r.content))?;
+            writeln!(xml, "    </definition>")?;
         }
-        writeln!(xml, "  </level_2_semantic>").unwrap();
+        writeln!(xml, "  </level_2_semantic>")?;
     }
 
     // Level 3: Episodic (History/Logs)
     if max_level >= 3 {
-        writeln!(xml, "  <level_3_episodic>").unwrap();
+        writeln!(xml, "  <level_3_episodic>")?;
         for r in result.level_3_episodic {
             writeln!(
                 xml,
                 "    <event score=\"{:.3}\" path=\"{}\">",
                 r.score,
                 escape_xml(&r.path)
-            )
-            .unwrap();
-            writeln!(xml, "      {}", escape_xml(&r.content)).unwrap();
-            writeln!(xml, "    </event>").unwrap();
+            )?;
+            writeln!(xml, "      {}", escape_xml(&r.content))?;
+            writeln!(xml, "    </event>")?;
         }
-        writeln!(xml, "  </level_3_episodic>").unwrap();
+        writeln!(xml, "  </level_3_episodic>")?;
     }
 
-    writeln!(xml, "</xavier_context_pack>").unwrap();
-    xml
+    writeln!(xml, "</xavier_context_pack>")?;
+    Ok(())
 }
 
 fn escape_xml(s: &str) -> String {

--- a/src/memory/sqlite_vec_store/schema_impl.rs
+++ b/src/memory/sqlite_vec_store/schema_impl.rs
@@ -8,8 +8,14 @@ use super::{vector, VecSqliteMemoryStore};
 
 impl SchemaInitializer for VecSqliteMemoryStore {
     fn init_schema(&self) -> Result<()> {
-        let rt = tokio::runtime::Handle::try_current()
-            .unwrap_or_else(|_| tokio::runtime::Runtime::new().unwrap().handle().clone());
+        let rt = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => handle,
+            Err(_) => {
+                let runtime = tokio::runtime::Runtime::new()
+                    .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {}", e))?;
+                runtime.handle().clone()
+            }
+        };
         rt.block_on(self.init_schema_async())
     }
 }

--- a/src/secrets/audit.rs
+++ b/src/secrets/audit.rs
@@ -11,7 +11,9 @@ pub struct QmdAuditLogger {
 impl QmdAuditLogger {
     pub fn new() -> Self {
         let project_id = "metrics";
-        ConnectionManager::global().connect(project_id, ".").unwrap();
+        if let Err(e) = ConnectionManager::global().connect(project_id, ".") {
+            tracing::warn!("QmdAuditLogger failed to connect to metrics database: {}", e);
+        }
         Self { project_id: project_id.to_string() }
     }
 
@@ -36,8 +38,14 @@ impl QmdAuditLogger {
 
 impl SchemaInitializer for QmdAuditLogger {
     fn init_schema(&self) -> anyhow::Result<()> {
-        let rt = tokio::runtime::Handle::try_current()
-            .unwrap_or_else(|_| tokio::runtime::Runtime::new().unwrap().handle().clone());
+        let rt = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => handle,
+            Err(_) => {
+                let runtime = tokio::runtime::Runtime::new()
+                    .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {}", e))?;
+                runtime.handle().clone()
+            }
+        };
         rt.block_on(self.init_schema_async())
     }
 }

--- a/src/security/threat_store.rs
+++ b/src/security/threat_store.rs
@@ -116,8 +116,14 @@ impl SecurityThreatStore {
 
 impl SchemaInitializer for SecurityThreatStore {
     fn init_schema(&self) -> Result<()> {
-        let rt = tokio::runtime::Handle::try_current()
-            .unwrap_or_else(|_| tokio::runtime::Runtime::new().unwrap().handle().clone());
+        let rt = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => handle,
+            Err(_) => {
+                let runtime = tokio::runtime::Runtime::new()
+                    .map_err(|e| anyhow::anyhow!("failed to create tokio runtime: {}", e))?;
+                runtime.handle().clone()
+            }
+        };
         rt.block_on(self.init_schema_async())
     }
 }

--- a/src/session/auto_save.rs
+++ b/src/session/auto_save.rs
@@ -299,7 +299,10 @@ async fn record_failed_sync(
         "latency_ms": latency_ms,
     });
     
-    fs::write(&filepath, serde_json::to_string_pretty(&record).unwrap())
+    let json = serde_json::to_string_pretty(&record)
+        .map_err(|e| format!("failed to serialize failed-sync record: {}", e))?;
+
+    fs::write(&filepath, json)
         .await
         .map_err(|e| format!("failed to write failed-sync record: {}", e))?;
     

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -22,7 +22,9 @@ impl TimeMetricsStore {
     /// Create a new TimeMetricsStore
     pub fn new() -> Self {
         let project_id = "metrics";
-        ConnectionManager::global().connect(project_id, ".").unwrap(); // Use default path logic in manager
+        if let Err(e) = ConnectionManager::global().connect(project_id, ".") {
+            tracing::warn!("TimeMetricsStore failed to connect to metrics database: {}", e);
+        }
         Self { project_id: project_id.to_string() }
     }
 
@@ -134,8 +136,14 @@ impl SchemaInitializer for TimeMetricsStore {
     /// Initialize the time_metrics table schema
     fn init_schema(&self) -> Result<()> {
         // We can now run this directly since init_schema_async uses spawn_blocking internally via ConnectionManager
-        let rt = tokio::runtime::Handle::try_current()
-            .unwrap_or_else(|_| tokio::runtime::Runtime::new().unwrap().handle().clone());
+        let rt = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => handle,
+            Err(_) => {
+                let runtime = tokio::runtime::Runtime::new()
+                    .context("failed to create tokio runtime for schema initialization")?;
+                runtime.handle().clone()
+            }
+        };
 
         rt.block_on(self.init_schema_async())
     }

--- a/tests/error_test.rs
+++ b/tests/error_test.rs
@@ -1,0 +1,7 @@
+use xavier::domain::AppError;
+
+#[test]
+fn test_app_error_usage() {
+    let err = AppError::Internal("test".to_string());
+    assert_eq!(format!("{}", err), "Internal error: test");
+}


### PR DESCRIPTION
This PR addresses the issue of excessive `.unwrap()` calls in production code. 

Key changes:
1. **New Error Type**: Introduced `xavier::domain::AppError` for structured error reporting.
2. **Safe Runtime Acquisition**: Replaced multiple patterns of `tokio::runtime::Runtime::new().unwrap()` with a safer match that tries to get the current handle first.
3. **Database Connection Resilience**: Added error logging instead of panicking when connecting to non-critical metrics databases.
4. **XML Generation Refactor**: Eliminated over 20 `unwrap()` calls in `src/memory/pack.rs` by making the generation function return a `Result`.
5. **Miscellaneous Fixes**: Addressed `unwrap()` calls in `connection_manager.rs`, `session/auto_save.rs`, and `enterprise/rate_limit.rs`.

The changes ensure that common failure points (like database connection issues or XML formatting errors) result in logged warnings or propagated errors rather than application crashes.

Fixes #496

---
*PR created automatically by Jules for task [12059077958987712613](https://jules.google.com/task/12059077958987712613) started by @iberi22*